### PR TITLE
Add tests to account for whitespace

### DIFF
--- a/exercises/run-length-encoding/src/test/scala/RunLengthEncodingTests.scala
+++ b/exercises/run-length-encoding/src/test/scala/RunLengthEncodingTests.scala
@@ -51,7 +51,7 @@ class RunLengthEncodingTests extends FunSuite with Matchers {
 
   test("decode with whitespace") {
     pending
-    RunLengthEncoding.decode("12WB12W3B24WB") should be ("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
+    RunLengthEncoding.decode("  hs2q q2w  ") should be ("  hsqq qww  ")
   }
 
   test("decode(encode(...)) combination") {

--- a/exercises/run-length-encoding/src/test/scala/RunLengthEncodingTests.scala
+++ b/exercises/run-length-encoding/src/test/scala/RunLengthEncodingTests.scala
@@ -37,8 +37,19 @@ class RunLengthEncodingTests extends FunSuite with Matchers {
     RunLengthEncoding.encode("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB") should
       be ("12WB12W3B24WB")
   }
-
+  
   test("decode with single values") {
+    pending
+    RunLengthEncoding.decode("12WB12W3B24WB") should be ("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
+  }
+   
+  test("encode with whitespace") {
+    pending
+    RunLengthEncoding.encode("  hsqq qww  ") should
+      be ("  hs2q q2w  ")
+  }
+
+  test("decode with whitespace") {
     pending
     RunLengthEncoding.decode("12WB12W3B24WB") should be ("WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
   }


### PR DESCRIPTION
Currently only the decode encode combination has whitespace, which doesn't reflect when the whitespace is being encoded like a regular character. The README explicitly states that whitespace should remain unchanged.