### PR TITLE
Create EtlTestGenereator, update EtlTest and example. Refs #370, #331

### DIFF
--- a/exercises/etl/example.scala
+++ b/exercises/etl/example.scala
@@ -1,4 +1,4 @@
-object ETL {
+object Etl {
   def transform(m: Map[Int, Seq[String]]): Map[String, Int] = m.flatMap { case (key, strings) =>
     Map(strings.map(_.toLowerCase -> key): _*)
   }

--- a/exercises/etl/src/test/scala/EtlTest.scala
+++ b/exercises/etl/src/test/scala/EtlTest.scala
@@ -1,46 +1,32 @@
-import org.scalatest._
+import org.scalatest.{Matchers, FunSuite}
 
-class TransformTest extends FunSuite with Matchers {
-  test ("transform one value") {
-    val old = Map(1 -> Seq("WORLD"))
+/** @version 1.0.0 */
+class EtlTest extends FunSuite with Matchers {
 
-    ETL.transform(old) should be (Map("world" -> 1))
+  test("a single letter") {
+    Etl.transform(Map(1 -> Seq("A"))) should be(Map("a" -> 1))
   }
 
-  test ("transform more values") {
+  test("single score with multiple letters") {
     pending
-    val old = Map(1 -> Seq("WORLD", "GSCHOOLERS"))
-    val expected = Map("world" -> 1, "gschoolers" -> 1)
-
-    ETL.transform(old) should be (expected)
+    Etl.transform(Map(1 -> Seq("A", "E", "I", "O", "U"))) should be(Map("a" -> 1,
+      "e" -> 1, "i" -> 1, "o" -> 1, "u" -> 1))
   }
 
-  test ("more keys") {
+  test("multiple scores with multiple letters") {
     pending
-    val old = Map(1 -> Seq("APPLE", "ARTICHOKE"), 2 -> Seq("BOAT", "BALLERINA"))
-    val expected = Map("apple" -> 1, "artichoke" -> 1, "boat" -> 2, "ballerina" -> 2)
-    ETL.transform(old) should be (expected)
+    Etl.transform(Map(1 -> Seq("A", "E"), 2 -> Seq("D", "G"))) should be(Map("a" -> 1,
+      "d" -> 2, "e" -> 1, "g" -> 2))
   }
 
-  test ("full dataset") {
+  test("multiple scores with differing numbers of letters") {
     pending
-    val old = Map(
-      1 -> Seq("A", "E", "I", "O", "U", "L", "N", "R", "S", "T"),
-      2 -> Seq("D", "G"),
-      3 -> Seq("B", "C", "M", "P"),
-      4 -> Seq("F", "H", "V", "W", "Y"),
-      5 -> Seq("K"),
-      8 -> Seq("J", "X"),
-      10 -> Seq("Q", "Z")
-    )
-    val expected = Map(
-      "a" -> 1, "b" -> 3, "c" -> 3, "d" -> 2, "e" -> 1,
-      "f" -> 4, "g" -> 2, "h" -> 4, "i" -> 1, "j" -> 8,
-      "k" -> 5, "l" -> 1, "m" -> 3, "n" -> 1, "o" -> 1,
-      "p" -> 3, "q" -> 10, "r" -> 1, "s" -> 1, "t" -> 1,
-      "u" -> 1, "v" -> 4, "w" -> 4, "x" -> 8, "y" -> 4,
-      "z" -> 10
-    )
-    ETL.transform(old) should be (expected)
+    Etl.transform(Map(1 -> Seq("A", "E", "I", "O", "U", "L", "N", "R", "S", "T"),
+      2 -> Seq("D", "G"), 3 -> Seq("B", "C", "M", "P"), 4 -> Seq("F", "H", "V", "W", "Y"),
+      5 -> Seq("K"), 8 -> Seq("J", "X"), 10 -> Seq("Q", "Z"))) should be(Map("a" -> 1,
+        "b" -> 3, "c" -> 3, "d" -> 2, "e" -> 1, "f" -> 4, "g" -> 2, "h" -> 4,
+        "i" -> 1, "j" -> 8, "k" -> 5, "l" -> 1, "m" -> 3, "n" -> 1, "o" -> 1, 
+        "p" -> 3, "q" -> 10, "r" -> 1, "s" -> 1, "t" -> 1, "u" -> 1, "v" -> 4,
+        "w" -> 4, "x" -> 8, "y" -> 4, "z" -> 10))
   }
 }

--- a/testgen/src/main/scala/EtlTestGenerator.scala
+++ b/testgen/src/main/scala/EtlTestGenerator.scala
@@ -1,0 +1,52 @@
+import java.io.File
+
+import testgen.TestSuiteBuilder.{toString, _}
+import testgen._
+
+object EtlTestGenerator {
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/etl.json")
+
+    def seqToString(seq: Seq[String]): String = s"Seq(${seq.map(s => "\"" + s + "\"").mkString(", ")})"
+
+    def mapArgToString(arg: Map[String, List[String]]): String = {
+      s"Map(${arg.toSeq
+        .sortBy(_._1.toInt)
+        .map{case (key, xs) => key.toString + " -> " + seqToString(xs)}
+        .mkString(",\n")})"
+    }
+
+    def mapExpectedToString(arg: Map[String, Int]): String = {
+      s"Map(${arg.toSeq
+        .sortBy(_._1)
+        .map{case (key, value) => "\"" + key.toString + "\" -> " + value.toString}
+        .mkString(",\n")})"
+    }
+
+    def toString(expected: CanonicalDataParser.Expected): String = {
+      expected match {
+        case Left(_) => ""
+        case Right(m) => mapExpectedToString(m.asInstanceOf[Map[String, Int]])
+      }
+    }
+
+    def sutArgs(parseResult: CanonicalDataParser.ParseResult, argNames: String*): String =
+      argNames map (name => mapArgToString(parseResult(name).asInstanceOf[Map[String, List[String]]])) mkString(", ")
+
+    def fromLabeledTest(argNames: String*): ToTestCaseData =
+      withLabeledTest { sut =>
+        labeledTest =>
+          val args = sutArgs(labeledTest.result, argNames: _*)
+          val property = labeledTest.property
+          val sutCall =
+            s"""Etl.$property($args)"""
+          val expected = toString(labeledTest.expected)
+          TestCaseData(labeledTest.description, sutCall, expected)
+      }
+
+    val code = TestSuiteBuilder.build(file, fromLabeledTest("input"))
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}


### PR DESCRIPTION
Create EtlTestGenereator, update EtlTest and example. Refs #370, #331

* Created EtlTestGenerator. I don't see a clean way to generate "sutCalls" and "expected" values that wrap lines. So.. I ended up reformatting the generated code by hand. I think the generator should suffice for now, but can be imporved.
@abo64 : Do you have any thoughts on how to generate multiple line "sutCalls" or "exepected" vals?
* Updated EtlTest.scala
* Update example.scala to use mixed case object name.