### PR TITLE
 Create TriangleTestGenerator. Update TriangleTest. Refs #370, #331

### DIFF
--- a/config.json
+++ b/config.json
@@ -172,7 +172,6 @@
       "slug": "triangle",
       "difficulty": 3,
       "topics": [
-        "Enumerations",
         "Mathematics"
       ]
     },

--- a/exercises/triangle/example.scala
+++ b/exercises/triangle/example.scala
@@ -1,24 +1,8 @@
-import TriangleType.TriangleType
-
-class Triangle(a: Int, b: Int, c: Int) {
-  def triangleType: TriangleType =
-    if (List(a, b, c).count(_ <= 0) > 0 || !checkInequality) TriangleType.Illogical
-    else if (a == b && b == c) TriangleType.Equilateral
-    else if (a == b || a == c || b == c) TriangleType.Isosceles
-    else TriangleType.Scalene
-
+case class Triangle(a: Double, b: Double, c: Double) {
   private def checkInequality = a + b >= c  &&  a + c >= b && b + c >= a
-}
 
-object Triangle {
-  def apply(a: Int, b: Int, c: Int) = new Triangle(a, b, c)
-}
-
-object TriangleType extends Enumeration {
-  type TriangleType = Value
-
-  val Equilateral = Value("Equilateral")
-  val Isosceles = Value("Isosceles")
-  val Scalene = Value("Scalene")
-  val Illogical = Value("Illogical")
+  val illogical: Boolean = List(a, b, c).count(_ <= 0) > 0 || !checkInequality
+  val isosceles: Boolean = !illogical && (a == b || a == c || b == c)
+  val equilateral: Boolean = !illogical && ( a == b && b == c)
+  val scalene: Boolean = !illogical && !isosceles && !equilateral
 }

--- a/exercises/triangle/src/test/scala/TriangleTest.scala
+++ b/exercises/triangle/src/test/scala/TriangleTest.scala
@@ -1,42 +1,89 @@
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{Matchers, FunSuite}
 
-class TriangleTest extends FlatSpec with Matchers {
-  it should "calc Equilateral" in {
-    Triangle(2, 2, 2).triangleType should equal(TriangleType.Equilateral)
+/** @version 1.0.0 */
+class TriangleTest extends FunSuite with Matchers {
+
+  test("equilateral - true if all sides are equal") {
+    Triangle(2, 2, 2).equilateral should be (true)
   }
 
-  it should "calc Equilateral2" in {
+  test("equilateral - false if any side is unequal") {
     pending
-    Triangle(10, 10, 10).triangleType should equal(TriangleType.Equilateral)
+    Triangle(2, 3, 2).equilateral should be (false)
   }
 
-  it should "calc Isosceles" in {
+  test("equilateral - false if no sides are equal") {
     pending
-    Triangle(3, 4, 4).triangleType should equal(TriangleType.Isosceles)
+    Triangle(5, 4, 6).equilateral should be (false)
   }
 
-  it should "calc Isosceles2" in {
+  test("equilateral - All zero sides are illegal, so the triangle is not equilateral") {
     pending
-    Triangle(4, 3, 4).triangleType should equal(TriangleType.Isosceles)
+    Triangle(0, 0, 0).equilateral should be (false)
   }
 
-  it should "calc Scalene" in {
+  test("equilateral - sides may be floats") {
     pending
-    Triangle(3, 4, 5).triangleType should equal(TriangleType.Scalene)
+    Triangle(0.5, 0.5, 0.5).equilateral should be (true)
   }
 
-  it should "calc Illogical" in {
+  test("isosceles - true if last two sides are equal") {
     pending
-    Triangle(1, 1, 50).triangleType should equal(TriangleType.Illogical)
+    Triangle(3, 4, 4).isosceles should be (true)
   }
 
-  it should "calc Illogical with zero length side" in {
+  test("isosceles - true if first two sides are equal") {
     pending
-    Triangle(0, 2, 1).triangleType should equal(TriangleType.Illogical)
+    Triangle(4, 4, 3).isosceles should be (true)
   }
 
-  it should "calc Illogical with negative length side" in {
+  test("isosceles - true if first and last sides are equal") {
     pending
-    Triangle(1, 1, -1).triangleType should equal(TriangleType.Illogical)
+    Triangle(4, 3, 4).isosceles should be (true)
+  }
+
+  test("isosceles - equilateral triangles are also isosceles") {
+    pending
+    Triangle(4, 4, 4).isosceles should be (true)
+  }
+
+  test("isosceles - false if no sides are equal") {
+    pending
+    Triangle(2, 3, 4).isosceles should be (false)
+  }
+
+  test("isosceles - Sides that violate triangle inequality are not isosceles, even if two are equal") {
+    pending
+    Triangle(1, 1, 3).isosceles should be (false)
+  }
+
+  test("isosceles - sides may be floats") {
+    pending
+    Triangle(0.5, 0.4, 0.5).isosceles should be (true)
+  }
+
+  test("scalene - true if no sides are equal") {
+    pending
+    Triangle(5, 4, 6).scalene should be (true)
+  }
+
+  test("scalene - false if all sides are equal") {
+    pending
+    Triangle(4, 4, 4).scalene should be (false)
+  }
+
+  test("scalene - false if two sides are equal") {
+    pending
+    Triangle(4, 4, 3).scalene should be (false)
+  }
+
+  test("scalene - Sides that violate triangle inequality are not scalene, even if they are all different") {
+    pending
+    Triangle(7, 3, 2).scalene should be (false)
+  }
+
+  test("scalene - sides may be floats") {
+    pending
+    Triangle(0.5, 0.4, 0.6).scalene should be (true)
   }
 }

--- a/testgen/src/main/scala/TriangleTestGenerator.scala
+++ b/testgen/src/main/scala/TriangleTestGenerator.scala
@@ -1,0 +1,37 @@
+import java.io.File
+
+import testgen.TestSuiteBuilder._
+import testgen._
+
+object TriangleTestGenerator {
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/triangle.json")
+
+    def mapArgToString(arg: Any): String = {
+      arg match {
+        case vals: List[_] => vals.mkString(", ")
+        case _ => throw new IllegalStateException
+      }
+    }
+
+    def sutArgs(parseResult: CanonicalDataParser.ParseResult, argNames: String*): String =
+          argNames map (name => mapArgToString(parseResult(name))) mkString
+
+    def fromLabeledTest(argNames: String*): ToTestCaseData =
+      withLabeledTest { sut =>
+        labeledTest =>
+          val args = sutArgs(labeledTest.result, argNames: _*)
+          val func = labeledTest.property.mkString
+          val sutCall = s"""Triangle(${args}).$func"""
+          val expected =
+            labeledTest.expected.fold(Function.const("true"), x => s"$x")
+          TestCaseData(labeledTest.property + " - " + labeledTest.description, sutCall, expected)
+      }
+
+    val code = TestSuiteBuilder.build(file,
+        fromLabeledTest("sides"))
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}


### PR DESCRIPTION
*  Create TriangleTestGenerator. 
* Update TriangleTest
* Rework example.scala to conform to new class/function signature. The old example used enumeration to represent the triangle type. A triangle could only be a single type. Only being a single type is invalid according to test - "equilateral triangles are also isosceles".  I removed the enumeration from the example. Now the class supports `isosceles`, `equilateral` and `scalene` functions as spec'd in the canonical-data.json.