### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,14 +5,20 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "1fadd9c3-a7c9-4355-aef9-82e0df3d45b9",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings"
       ]
     },
     {
+      "uuid": "57b76aba-a485-464d-84ba-e9a445b25be6",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -21,7 +27,10 @@
       ]
     },
     {
+      "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Filtering",
@@ -29,7 +38,10 @@
       ]
     },
     {
+      "uuid": "b600cda0-f5b8-45b3-bfd0-7e0c19a0b073",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Integers",
@@ -37,7 +49,10 @@
       ]
     },
     {
+      "uuid": "f147966d-97ec-4479-8679-8cad942b499a",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Dates",
@@ -46,7 +61,10 @@
       ]
     },
     {
+      "uuid": "4c3710dc-fac2-4056-b4ac-945b67c08068",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Dates",
@@ -55,7 +73,10 @@
       ]
     },
     {
+      "uuid": "1fe9f43a-7774-4fbd-864b-eff7749ebbc6",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Integers",
@@ -63,14 +84,20 @@
       ]
     },
     {
+      "uuid": "e6f96ae1-6736-42f4-b74d-14a4aa8aa5fc",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Strings"
       ]
     },
     {
+      "uuid": "b469a197-adf4-4d02-b129-07f993104054",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Maps",
@@ -79,7 +106,10 @@
       ]
     },
     {
+      "uuid": "6d136d51-390a-46a7-b42b-fdecff7b622a",
       "slug": "accumulate",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Generics",
@@ -88,7 +118,10 @@
       ]
     },
     {
+      "uuid": "54ff0017-7c53-4e83-a3bd-aff2953185b7",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "Strings",
@@ -97,7 +130,10 @@
       ]
     },
     {
+      "uuid": "5a31217f-02fd-4be4-b64f-7a93f36f5140",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -106,7 +142,10 @@
       ]
     },
     {
+      "uuid": "d7f7b64e-1dba-400e-a9c1-acd521d21753",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Optional values",
@@ -116,7 +155,10 @@
       ]
     },
     {
+      "uuid": "d3a10b82-ae65-4a99-968d-4f1bec62b88a",
       "slug": "strain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Generics",
@@ -125,7 +167,10 @@
       ]
     },
     {
+      "uuid": "d06505fb-3844-481a-bf7a-4e05545119f0",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -133,7 +178,10 @@
       ]
     },
     {
+      "uuid": "d21f16ce-8e6e-436e-918b-e973cfc7c2a0",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Lists",
@@ -144,7 +192,10 @@
       ]
     },
     {
+      "uuid": "39b2350c-60b5-4da0-9fb9-26f75a4bad6d",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Optional values",
@@ -152,7 +203,10 @@
       ]
     },
     {
+      "uuid": "a4797d24-9293-41b2-b630-3ac9e3840d47",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -160,7 +214,10 @@
       ]
     },
     {
+      "uuid": "fc58b128-24a8-48e7-90db-b4843fbdf40a",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Optional values",
@@ -169,14 +226,20 @@
       ]
     },
     {
+      "uuid": "2be75924-fce4-49fa-b52e-6cdcf222b283",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Mathematics"
       ]
     },
     {
+      "uuid": "612b8880-1dd1-410d-b530-c66ec9edc1b3",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Discriminated unions",
@@ -186,7 +249,10 @@
       ]
     },
     {
+      "uuid": "f653decb-f7fa-47ff-81a6-2b3981261ea7",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Searching",
@@ -195,7 +261,10 @@
       ]
     },
     {
+      "uuid": "e810d2eb-5c90-4135-8db8-0bda54a33d2e",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Lists",
@@ -204,7 +273,10 @@
       ]
     },
     {
+      "uuid": "9f5ee7aa-943b-4151-8530-def1428fc00f",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Filtering",
@@ -213,7 +285,10 @@
       ]
     },
     {
+      "uuid": "261f75c1-df67-4c62-a2e9-ce13550f5de3",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Enumerations",
@@ -221,7 +296,10 @@
       ]
     },
     {
+      "uuid": "f6d61a0e-068b-4519-8d4d-563713be6168",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -229,7 +307,10 @@
       ]
     },
     {
+      "uuid": "a6a06d7f-af28-4c42-a870-0de2c9e896c2",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Time",
@@ -237,7 +318,10 @@
       ]
     },
     {
+      "uuid": "e6a3354e-dd32-413f-856d-53c81bd0d728",
       "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Strings",
@@ -246,7 +330,10 @@
       ]
     },
     {
+      "uuid": "15047d95-671b-4163-96b2-834ec54ea3d5",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "Text formatting",
@@ -256,7 +343,10 @@
       ]
     },
     {
+      "uuid": "c6c37479-a030-44ba-9da5-97eb77233ac6",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -266,7 +356,10 @@
       ]
     },
     {
+      "uuid": "73770426-74a8-498f-a37c-1b12aaf71281",
       "slug": "house",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -275,7 +368,10 @@
       ]
     },
     {
+      "uuid": "35a0ff51-6c85-4a39-8017-62e8eabd1c21",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -284,7 +380,10 @@
       ]
     },
     {
+      "uuid": "10c53e9d-8fa6-486c-b68a-be821dec5010",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Maps",
@@ -293,7 +392,10 @@
       ]
     },
     {
+      "uuid": "54633841-b60f-49a0-9f95-aeda09de6232",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Sequences",
@@ -302,7 +404,10 @@
       ]
     },
     {
+      "uuid": "c03319c6-1a2b-4f26-a943-242ccc6a295e",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Maps",
@@ -310,14 +415,20 @@
       ]
     },
     {
+      "uuid": "50a7cf00-7f5e-4f38-9a13-c8ff5c895723",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Dates"
       ]
     },
     {
+      "uuid": "49d45a39-c8de-4b25-9ee2-5e08de8721c0",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Lists",
@@ -327,7 +438,10 @@
       ]
     },
     {
+      "uuid": "8e311809-1de4-44c3-923a-ffd863843e6b",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Lists",
@@ -336,7 +450,10 @@
       ]
     },
     {
+      "uuid": "adcf2a9b-2f6c-490f-b441-ad413a03fee7",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Integers",
@@ -347,7 +464,10 @@
       ]
     },
     {
+      "uuid": "1218f854-ebb9-40dd-9487-ccc4d09c9a43",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Enumerations",
@@ -356,7 +476,10 @@
       ]
     },
     {
+      "uuid": "7e81f24e-c892-4e45-b0bb-6c6420ba1f0e",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -367,7 +490,10 @@
       ]
     },
     {
+      "uuid": "34a134c4-f9f5-46c4-97db-2f6c8c1e97f5",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Control-flow (loops)",
@@ -376,7 +502,10 @@
       ]
     },
     {
+      "uuid": "0e858f22-401b-44ad-b972-766e2f38e5d5",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Integers",
@@ -386,7 +515,10 @@
       ]
     },
     {
+      "uuid": "aa135256-28c8-4e3e-a942-8ae5ae996ab5",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Matrices",
@@ -396,7 +528,10 @@
       ]
     },
     {
+      "uuid": "876a07ce-0ee4-4ded-bab3-c9b3f8746d57",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Strings",
@@ -404,7 +539,10 @@
       ]
     },
     {
+      "uuid": "163d247a-1763-4876-870a-63deb3a3daa8",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Algorithms",
@@ -413,7 +551,10 @@
       ]
     },
     {
+      "uuid": "4c08ec90-4c5a-4dae-812c-52899b1a29cf",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Sequences",
@@ -422,7 +563,10 @@
       ]
     },
     {
+      "uuid": "168823e4-de57-40c0-ac8d-bec6ccf9c96d",
       "slug": "simple-linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Classes",
@@ -432,7 +576,10 @@
       ]
     },
     {
+      "uuid": "842f0674-fcf3-48c3-80ae-c6d43c65f270",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -441,7 +588,10 @@
       ]
     },
     {
+      "uuid": "6e379741-8337-41f3-9790-dc93cacdc9b6",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Optional values",
@@ -451,14 +601,20 @@
       ]
     },
     {
+      "uuid": "ec0334d9-df30-4e61-bea6-bd3f7c8d13e6",
       "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Parallellism"
       ]
     },
     {
+      "uuid": "b047cdd2-5afa-47a0-b48d-5c235c1099dc",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -468,7 +624,10 @@
       ]
     },
     {
+      "uuid": "9d25bf46-52d6-435e-a384-38c25517f8ee",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -476,7 +635,10 @@
       ]
     },
     {
+      "uuid": "1af833c7-2e0d-4c96-a3a9-d4812df5d1a1",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -486,7 +648,10 @@
       ]
     },
     {
+      "uuid": "8956383c-bea2-4bcc-b7af-df19f94e15e6",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Strings",
@@ -495,7 +660,10 @@
       ]
     },
     {
+      "uuid": "60deb77c-45f2-48a1-bff8-b0cef3b07500",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Text formatting",
@@ -503,7 +671,10 @@
       ]
     },
     {
+      "uuid": "bec1be3e-2d1c-4cb7-9398-dd0249e79d2e",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Lists",
@@ -512,14 +683,20 @@
       ]
     },
     {
+      "uuid": "e0810022-d3ea-463a-97da-dfdac08e3c63",
       "slug": "spiral-matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Matrices"
       ]
     },
     {
+      "uuid": "0605da19-048e-4a1f-b508-5d77d1e384a5",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Sets",
@@ -528,7 +705,10 @@
       ]
     },
     {
+      "uuid": "a557f7e3-9fc0-4cd8-bab1-b4d8fc88402d",
       "slug": "parallel-letter-frequency",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Maps",
@@ -540,14 +720,20 @@
       ]
     },
     {
+      "uuid": "5ce09233-9ec1-4422-aa97-2d90ea67146b",
       "slug": "book-store",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "Recursion"
       ]
     },
     {
+      "uuid": "c7838d98-35db-4a84-914e-c05cafda2bed",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Optional values",
@@ -556,7 +742,10 @@
       ]
     },
     {
+      "uuid": "fc57c00f-ca56-499d-bb46-0ce006b60923",
       "slug": "palindrome-products",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Sets",
@@ -566,7 +755,10 @@
       ]
     },
     {
+      "uuid": "221be13e-da2a-4f0a-9702-84744cbcaca6",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Lists",
@@ -577,7 +769,10 @@
       ]
     },
     {
+      "uuid": "088e1441-a648-4dc4-ad13-c5fdd8e8a104",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Strings",
@@ -585,7 +780,10 @@
       ]
     },
     {
+      "uuid": "f70d2b0c-9660-4538-9897-2f233b93d0c3",
       "slug": "binary-search-tree",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Searching",
@@ -595,7 +793,10 @@
       ]
     },
     {
+      "uuid": "755b5cf5-97f2-41c1-9b0b-24e6db68b7eb",
       "slug": "rail-fence-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Strings",
@@ -604,7 +805,10 @@
       ]
     },
     {
+      "uuid": "9ea2b27f-4c3a-463d-8869-4e930808ce93",
       "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "Algorithms",
@@ -613,7 +817,10 @@
       ]
     },
     {
+      "uuid": "d619cdc2-b8b7-442d-a2b2-41383c33d219",
       "slug": "dominoes",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Lists",
@@ -623,7 +830,10 @@
       ]
     },
     {
+      "uuid": "00a09826-f63b-4558-8ad0-6cdb7836dfea",
       "slug": "sublist",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Generics",
@@ -632,7 +842,10 @@
       ]
     },
     {
+      "uuid": "04c3197c-cd3d-4853-af3f-50c189af80c7",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Lists",
@@ -642,7 +855,10 @@
       ]
     },
     {
+      "uuid": "ded3ae4c-43a7-46df-b43b-42aab419c2d8",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Mathematics",
@@ -653,7 +869,10 @@
       ]
     },
     {
+      "uuid": "62dd342a-591c-497f-8f3a-64748952b1af",
       "slug": "change",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Integers",
@@ -663,7 +882,10 @@
       ]
     },
     {
+      "uuid": "5ea6b0e1-513e-462f-9741-46f060638a92",
       "slug": "connect",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Recursion",
@@ -675,14 +897,20 @@
       ]
     },
     {
+      "uuid": "eb9387d6-3fac-460b-ad14-657c0f4d2d88",
       "slug": "zebra-puzzle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Logic"
       ]
     },
     {
+      "uuid": "e0e0ef68-6759-42e3-8542-3d165f8900d7",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Strings",
@@ -692,7 +920,10 @@
       ]
     },
     {
+      "uuid": "64002f5b-e373-4850-92bf-88461d49376e",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Maps",
@@ -702,7 +933,10 @@
       ]
     },
     {
+      "uuid": "8b4c7142-6790-4d89-a5cb-fa094e2c969a",
       "slug": "sgf-parsing",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Parsing",
@@ -710,14 +944,20 @@
       ]
     },
     {
+      "uuid": "e6e88c52-b984-479d-8b9c-047d25f2aa47",
       "slug": "lens-person",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
 
       ]
     },
     {
+      "uuid": "12dbe514-848b-4fd2-868d-7f6195092e23",
       "slug": "variable-length-quantity",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "Discriminated unions",
@@ -727,7 +967,10 @@
       ]
     },
     {
+      "uuid": "bc5b07e2-f641-4fda-818d-12502cdbb066",
       "slug": "zipper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Generics",
@@ -736,20 +979,37 @@
       ]
     },
     {
+      "uuid": "2c85199f-4d09-485b-9925-3b21f81ee054",
       "slug": "forth",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Strings",
         "Mathematics",
         "Parsing"
       ]
+    },
+    {
+      "uuid": "6cc53fdc-4423-47fe-abac-7688259b0ac5",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "7c949a14-70dc-4034-874f-0c9e3217fcf8",
+      "slug": "hexadecimal",
+      "deprecated": true
+    },
+    {
+      "uuid": "403063a8-9f29-409a-8bf4-a2400521e19b",
+      "slug": "octal",
+      "deprecated": true
+    },
+    {
+      "uuid": "616e49fe-b6eb-4384-9af4-b8413d4d0eab",
+      "slug": "trinary",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "binary",
-    "hexadecimal",
-    "octal",
-    "trinary"
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16