### PR TITLE
Create PascalsTriangleTestGenerator. 

### DIFF
--- a/exercises/pascals-triangle/example.scala
+++ b/exercises/pascals-triangle/example.scala
@@ -1,5 +1,5 @@
 object PascalsTriangle {
-  def triangle(n: Int): List[List[Int]] =
+  def rows(n: Int): List[List[Int]] =
     (for (row <- 1 to n) yield triRow(row)).toList
 
   private def triRow(row: Int): List[Int] = {

--- a/exercises/pascals-triangle/src/test/scala/PascalsTriangleTest.scala
+++ b/exercises/pascals-triangle/src/test/scala/PascalsTriangleTest.scala
@@ -1,37 +1,34 @@
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{Matchers, FunSuite}
 
-class PascalsTriangleTest extends FlatSpec with Matchers {
-  it should "handle 1 row" in {
-    PascalsTriangle.triangle(1) should be (List(List(1)))
+/** @version 1.0.0 */
+class PascalsTriangleTest extends FunSuite with Matchers {
+
+  test("zero rows") {
+    PascalsTriangle.rows(0) should be (List())
   }
 
-  it should "handle 2 rows" in {
+  test("single row") {
     pending
-    PascalsTriangle.triangle(2) should be (List(List(1), List(1, 1)))
+    PascalsTriangle.rows(1) should be (List(List(1)))
   }
 
-  it should "handle 3 rows" in {
+  test("two rows") {
     pending
-    PascalsTriangle.triangle(3) should be (List(List(1), List(1, 1), List(1, 2, 1)))
+    PascalsTriangle.rows(2) should be (List(List(1), List(1, 1)))
   }
 
-  it should "handle 4 rows" in {
+  test("three rows") {
     pending
-    PascalsTriangle.triangle(4) should be (List(List(1), List(1, 1),
-      List(1, 2, 1), List(1, 3, 3, 1)))
+    PascalsTriangle.rows(3) should be (List(List(1), List(1, 1), List(1, 2, 1)))
   }
 
-  it should "handle 5 rows" in {
+  test("four rows") {
     pending
-    PascalsTriangle.triangle(5) should be (List(List(1), List(1, 1),
-      List(1, 2, 1), List(1, 3, 3, 1), List(1, 4, 6, 4, 1)))
+    PascalsTriangle.rows(4) should be (List(List(1), List(1, 1), List(1, 2, 1), List(1, 3, 3, 1)))
   }
 
-  it should "handle 20 rows" in {
+  test("negative rows") {
     pending
-    PascalsTriangle.triangle(20).takeRight(1).head should be (List(1, 19,
-      171, 969, 3876, 11628, 27132, 50388, 75582, 92378,
-      92378, 75582, 50388, 27132, 11628, 3876, 969, 171,
-      19, 1))
+    PascalsTriangle.rows(-1) should be (List())
   }
 }

--- a/testgen/src/main/scala/PascalsTriangleTestGenerator.scala
+++ b/testgen/src/main/scala/PascalsTriangleTestGenerator.scala
@@ -1,0 +1,51 @@
+import java.io.File
+
+import testgen.TestSuiteBuilder._
+import testgen._
+
+object PascalsTriangleTestGenerator {
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/pascals-triangle.json")
+
+    def toStr(any: Any): String = {
+      any match {
+        case list: List[_] =>
+          val vals = list.map(s => toStr(s)).mkString(", ")
+          s"List($vals)"
+        case n: Int =>
+          if (n == -1)
+            "List()"
+          else
+            n.toString
+        case v => throw new IllegalStateException("Unexpected value - " + v)
+      }
+    }
+
+    def toString(expected: CanonicalDataParser.Expected): String = {
+        expected match {
+          case Left(error) => throw new IllegalStateException("Unexpected error - " + error)
+          case Right(exp) => toStr(exp)
+        }
+    }
+
+    def withLabeledTestOption(argNames: String*): ToOptionTestCaseData =
+      withLabeledTestOpt { sut =>
+        labeledTest =>
+          if (labeledTest.result.valuesIterator.contains(null)) {
+            None
+          } else {
+            val args = sutArgs(labeledTest.result, argNames: _*)
+            val property = labeledTest.property
+            val sutCall =
+              s"""$sut.$property($args)"""
+            val expected = toString(labeledTest.expected)
+            Some(TestCaseData(labeledTest.description, sutCall, expected))
+          }
+      }
+
+    val code = TestSuiteBuilder.buildFromOption(file, withLabeledTestOption("count"))
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}


### PR DESCRIPTION
* Create PascalsTriangleTestGenerator. 
* Update PascalsTriangleTest. 
* Update example to conform to new function name.

Note that the test generator is written to ignore the test with `null` as the function param. I didn't think that a `null` param made much sense in the context of the defined function.
Also, for the `-1` error case, the example was returning an empty list. I left the example and test case to expect an empty list for the error case. I think there are plenty of other exercises that test `Option` and `Either`.

Ref #370, #331