### PR TITLE
Update CustomSetTestGenerator.scala. Update CustomSetTest.scala. Refs #370, #331

### DIFF
--- a/exercises/custom-set/src/test/scala/CustomSetTest.scala
+++ b/exercises/custom-set/src/test/scala/CustomSetTest.scala
@@ -1,6 +1,8 @@
 import org.scalatest.{FunSuite, Matchers}
 
+/** @version 1.0.1 */
 class CustomSetTest extends FunSuite with Matchers {
+
   // Empty test cases - Returns true if the set contains no elements
   test("sets with no elements are empty") {
     val set = CustomSet.fromList(List())
@@ -152,24 +154,24 @@ class CustomSetTest extends FunSuite with Matchers {
     pending
     val set = CustomSet.fromList(List())
     val expected = CustomSet.fromList(List(3))
-    CustomSet.isEqual(CustomSet.insert(set, 3 ), expected) should be (true)
+    CustomSet.isEqual(CustomSet.insert(set, 3), expected) should be (true)
   }
 
   test("add to non-empty set") {
     pending
     val set = CustomSet.fromList(List(1, 2, 4))
     val expected = CustomSet.fromList(List(1, 2, 3, 4))
-    CustomSet.isEqual(CustomSet.insert(set, 3 ), expected) should be (true)
+    CustomSet.isEqual(CustomSet.insert(set, 3), expected) should be (true)
   }
 
   test("adding an existing element does not change the set") {
     pending
     val set = CustomSet.fromList(List(1, 2, 3))
     val expected = CustomSet.fromList(List(1, 2, 3))
-    CustomSet.isEqual(CustomSet.insert(set, 3 ), expected) should be (true)
+    CustomSet.isEqual(CustomSet.insert(set, 3), expected) should be (true)
   }
 
-  // Intersection test cases - Intersect returns a set of all shared elements
+  // Intersection test cases - Intersection returns a set of all shared elements
   test("intersection of two empty sets is an empty set") {
     pending
     val set1 = CustomSet.fromList(List())

--- a/testgen/src/main/scala/CustomSetTestGenerator.scala
+++ b/testgen/src/main/scala/CustomSetTestGenerator.scala
@@ -14,12 +14,13 @@ class CustomSetTestGenerator {
   implicit val differenceTestCasesReader = Json.reads[DifferenceTestCase]
   implicit val unionTestCasesReader = Json.reads[UnionTestCase]
 
-  private val filename = "custom-set.json"
+  private val filename = "src/main/resources/custom-set.json"
   private val fileContents = Source.fromFile(filename).getLines.mkString
   private val json = Json.parse(fileContents)
 
   def write {
     val testBuilder = new TestBuilder("CustomSetTest")
+    setVersion(testBuilder)
     addEmptyTests(testBuilder)
     addContainsTests(testBuilder)
     addSubsetTests(testBuilder)
@@ -32,17 +33,21 @@ class CustomSetTestGenerator {
     testBuilder.toFile
   }
 
+  private def setVersion(testBuilder: TestBuilder): Unit = {
+    testBuilder.setVersion((json \ "version").get.as[String])
+  }
+
   private def addEmptyTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Empty test cases - " +  (json \ "empty" \ "description").get.as[String]
+      "Empty test cases - " +  (json \ "cases" \ 0 \ "description").get.as[String]
 
-    val emptyTestCases = (json \ "empty" \ "cases").get.as[List[EmptyTestCase]]
+    val emptyTestCases = (json \ "cases" \ 0 \ "cases").get.as[List[EmptyTestCase]]
 
     implicit def testCaseToGen(tc: EmptyTestCase): TestCaseGen = {
       val set = s"CustomSet.fromList(${tc.set})"
       val callSUT = s"CustomSet.empty(set)"
       val expected = tc.expected.toString
-      val result = s"val set = $callSUT"
+      val result = s"val set = $set"
       val checkResult = s"$callSUT should be ($expected)"
 
       TestCaseGen(tc.description, callSUT, expected, result, checkResult)
@@ -53,9 +58,9 @@ class CustomSetTestGenerator {
 
   private def addContainsTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Contains test cases - " + (json \ "contains" \ "description").get.as[String]
+      "Contains test cases - " + (json \ "cases" \ 1 \ "description").get.as[String]
 
-    val containsTestCases = (json \ "contains" \ "cases").get.as[List[ContainsTestCase]]
+    val containsTestCases = (json \ "cases" \ 1 \ "cases").get.as[List[ContainsTestCase]]
 
     implicit def testCaseToGen(tc: ContainsTestCase): TestCaseGen = {
       val set = s"CustomSet.fromList(${tc.set})"
@@ -72,9 +77,9 @@ class CustomSetTestGenerator {
 
   private def addSubsetTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Subset test cases - " + (json \ "subset" \ "description").get.as[String]
+      "Subset test cases - " + (json \"cases" \ 2 \ "description").get.as[String]
 
-    val subsetTestCases = (json \ "subset" \ "cases").get.as[List[SubsetTestCase]]
+    val subsetTestCases = (json \ "cases" \ 2 \ "cases").get.as[List[SubsetTestCase]]
 
     implicit def testCaseToGen(tc: SubsetTestCase): TestCaseGen = {
       val set1 = s"CustomSet.fromList(${tc.set1})"
@@ -94,9 +99,9 @@ s"""val set1 = $set1
 
   private def addDisjointTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Disjoint test cases - " + (json \ "disjoint" \ "description").get.as[String]
+      "Disjoint test cases - " + (json \ "cases" \ 3 \ "description").get.as[String]
 
-    val disjointTestCases = (json \ "disjoint" \ "cases").get.as[List[DisjointTestCase]]
+    val disjointTestCases = (json \ "cases" \ 3 \ "cases").get.as[List[DisjointTestCase]]
 
     implicit def testCaseToGen(tc: DisjointTestCase): TestCaseGen = {
       val set1 = s"CustomSet.fromList(${tc.set1})"
@@ -116,9 +121,9 @@ s"""val set1 = $set1
 
   private def addEqualTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Equal test cases - " + (json \ "equal" \ "description").get.as[String]
+      "Equal test cases - " + (json \ "cases" \ 4 \ "description").get.as[String]
 
-    val equalTestCases = (json \ "equal" \ "cases").get.as[List[EqualTestCase]]
+    val equalTestCases = (json \ "cases" \ 4 \ "cases").get.as[List[EqualTestCase]]
 
     implicit def testCaseToGen(tc: EqualTestCase): TestCaseGen = {
       val set1 = s"CustomSet.fromList(${tc.set1})"
@@ -138,9 +143,9 @@ s"""val set1 = $set1
 
   private def addAddTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Add test cases - " + (json \ "add" \ "description").get.as[String]
+      "Add test cases - " + (json \ "cases" \ 5 \ "description").get.as[String]
 
-    val addTestCases = (json \ "add" \ "cases").get.as[List[AddTestCase]]
+    val addTestCases = (json \ "cases" \ 5 \ "cases").get.as[List[AddTestCase]]
 
     implicit def testCaseToGen(tc: AddTestCase): TestCaseGen = {
       val set = s"CustomSet.fromList(${tc.set})"
@@ -159,9 +164,9 @@ s"""val set = $set
 
   private def addIntersectionTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Intersection test cases - " + (json \ "intersection" \ "description").get.as[String]
+      "Intersection test cases - " + (json \ "cases" \ 6 \ "description").get.as[String]
 
-    val intersectionTestCases = (json \ "intersection" \ "cases").get.as[List[IntersectionTestCase]]
+    val intersectionTestCases = (json \ "cases" \ 6 \ "cases").get.as[List[IntersectionTestCase]]
 
     implicit def testCaseToGen(tc: IntersectionTestCase): TestCaseGen = {
       val set1 = s"CustomSet.fromList(${tc.set1})"
@@ -182,9 +187,9 @@ s"""val set1 = $set1
 
   private def addDifferenceTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Difference test cases - " + (json \ "difference" \ "description").get.as[String]
+      "Difference test cases - " + (json \ "cases" \ 7 \ "description").get.as[String]
 
-    val differenceTestCases = (json \ "difference" \ "cases").get.as[List[DifferenceTestCase]]
+    val differenceTestCases = (json \ "cases" \ 7 \ "cases").get.as[List[DifferenceTestCase]]
 
     implicit def testCaseToGen(tc: DifferenceTestCase): TestCaseGen = {
       val set1 = s"CustomSet.fromList(${tc.set1})"
@@ -205,9 +210,9 @@ s"""val set1 = $set1
 
   private def addUnionTests(testBuilder: TestBuilder): Unit = {
     val description =
-      "Union test cases - " + (json \ "union" \ "description").get.as[String]
+      "Union test cases - " + (json \ "cases" \ 8 \ "description").get.as[String]
 
-    val unionTestCases = (json \ "union" \ "cases").get.as[List[UnionTestCase]]
+    val unionTestCases = (json \ "cases" \ 8 \ "cases").get.as[List[UnionTestCase]]
 
     implicit def testCaseToGen(tc: UnionTestCase): TestCaseGen = {
       val set1 = s"CustomSet.fromList(${tc.set1})"

--- a/testgen/src/main/scala/TestBuilder.scala
+++ b/testgen/src/main/scala/TestBuilder.scala
@@ -19,6 +19,9 @@ class TestBuilder(testName: String) {
   private var imports: Seq[String] = Seq()
   def addImport(imprt: String): Unit = imports = imports :+ imprt
 
+  private var version: Option[String] = None
+  def setVersion(v: String): Unit = this.version = Some(v)
+
   private var testCases: Seq[(Seq[TestCaseGen], Option[String])] = Seq()
   def addTestCases(testCases: Seq[TestCaseGen], description: Option[String] = None): Unit =
     this.testCases = this.testCases :+ (testCases, description)
@@ -33,10 +36,17 @@ class TestBuilder(testName: String) {
 
   def build: String =
 s"""$printImports
+$printVersion
 class $testName extends FunSuite with Matchers {
 $printTestCases
 }
 """
+
+  private lazy val printVersion: String =
+    version match {
+      case Some(v) => s"""/** @version $v */"""
+      case None => ""
+    }
 
   private lazy val printImports: String =
     "import org.scalatest.{FunSuite, Matchers}\n" +


### PR DESCRIPTION
* Update CustomSetTestGenerator.scala.  I am not real thrilled on how I had to modify the json paths to reference the json elements for the updated json. The elements are referenced by index. 

I am not aware of a cleaner way to reference the json elements for each function call. I thought about rewriting the generator using the new generator scheme. But, the updated json format along with how the exercise is implemented would make this difficult...

* Update CustomSetTest.scala. 

Refs #370, #331