### PR TITLE
Create PigLatinTestGenerator.scala. Update PigLatinTest.scala. Refs #…

### DIFF
--- a/exercises/pig-latin/example.scala
+++ b/exercises/pig-latin/example.scala
@@ -5,13 +5,18 @@ object PigLatin {
 
   def translateWord(str: String): String = {
     val lowercase = str.toLowerCase
-    val before = lowercase.takeWhile(!_.isLetter)
-    val w1 = lowercase.drop(before.length)
-    val w2 = w1.takeWhile(_.isLetter)
-    val after = w1.drop(w2.length)
-    val (cs, w) = consonantCluster(w2)
 
-    before ++ w ++ cs ++ "ay" ++ after
+    if (Seq("yt", "xr").exists(pre => lowercase.startsWith(pre))) {
+      lowercase + "ay"
+    } else {
+      val before = lowercase.takeWhile(!_.isLetter)
+      val w1 = lowercase.drop(before.length)
+      val w2 = w1.takeWhile(_.isLetter)
+      val after = w1.drop(w2.length)
+      val (cs, w) = consonantCluster(w2)
+
+      before ++ w ++ cs ++ "ay" ++ after
+    }
   }
 
   private def consonantCluster(str: String): (String, String) = {

--- a/exercises/pig-latin/src/test/scala/PigLatinTest.scala
+++ b/exercises/pig-latin/src/test/scala/PigLatinTest.scala
@@ -1,33 +1,103 @@
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{Matchers, FunSuite}
 
-class PigLatinTest extends FlatSpec with Matchers {
-  it should "translate beginning with vowels" in {
+/** @version 1.0.0 */
+class PigLatinTest extends FunSuite with Matchers {
+
+  test("word beginning with a") {
     PigLatin.translate("apple") should be ("appleay")
+  }
+
+  test("word beginning with e") {
+    pending
     PigLatin.translate("ear") should be ("earay")
   }
 
-  it should "translate beginning with single letter consonant clusters" in {
+  test("word beginning with i") {
+    pending
+    PigLatin.translate("igloo") should be ("iglooay")
+  }
+
+  test("word beginning with o") {
+    pending
+    PigLatin.translate("object") should be ("objectay")
+  }
+
+  test("word beginning with u") {
+    pending
+    PigLatin.translate("under") should be ("underay")
+  }
+
+  test("word beginning with a vowel and followed by a qu") {
+    pending
+    PigLatin.translate("equal") should be ("equalay")
+  }
+
+  test("word beginning with p") {
     pending
     PigLatin.translate("pig") should be ("igpay")
+  }
+
+  test("word beginning with k") {
+    pending
     PigLatin.translate("koala") should be ("oalakay")
+  }
+
+  test("word beginning with y") {
+    pending
+    PigLatin.translate("yellow") should be ("ellowyay")
+  }
+
+  test("word beginning with x") {
+    pending
+    PigLatin.translate("xenon") should be ("enonxay")
+  }
+
+  test("word beginning with q without a following u") {
+    pending
     PigLatin.translate("qat") should be ("atqay")
   }
 
-  it should "translate beginning with multiple letter consonant clusters" in {
+  test("word beginning with ch") {
     pending
     PigLatin.translate("chair") should be ("airchay")
-    PigLatin.translate("therapy") should be ("erapythay")
-    PigLatin.translate("thrush") should be ("ushthray")
-    PigLatin.translate("school") should be ("oolschay")
   }
 
-  it should "translate beginning with consonant clusters with qu" in {
+  test("word beginning with qu") {
     pending
     PigLatin.translate("queen") should be ("eenquay")
+  }
+
+  test("word beginning with qu and a preceding consonant") {
+    pending
     PigLatin.translate("square") should be ("aresquay")
   }
 
-  it should "translate phrases" in {
+  test("word beginning with th") {
+    pending
+    PigLatin.translate("therapy") should be ("erapythay")
+  }
+
+  test("word beginning with thr") {
+    pending
+    PigLatin.translate("thrush") should be ("ushthray")
+  }
+
+  test("word beginning with sch") {
+    pending
+    PigLatin.translate("school") should be ("oolschay")
+  }
+
+  test("word beginning with yt") {
+    pending
+    PigLatin.translate("yttria") should be ("yttriaay")
+  }
+
+  test("word beginning with xr") {
+    pending
+    PigLatin.translate("xray") should be ("xrayay")
+  }
+
+  test("a whole phrase") {
     pending
     PigLatin.translate("quick fast run") should be ("ickquay astfay unray")
   }

--- a/testgen/src/main/scala/PigLatinTestGenerator.scala
+++ b/testgen/src/main/scala/PigLatinTestGenerator.scala
@@ -1,0 +1,16 @@
+import java.io.File
+
+import testgen.TestSuiteBuilder._
+import testgen._
+
+object PigLatinTestGenerator {
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/pig-latin.json")
+
+    val code =
+      TestSuiteBuilder.build(file, fromLabeledTest("input"))
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}


### PR DESCRIPTION
* Create PigLatinTestGenerator.scala. 
* Update PigLatinTest.scala. 
* Updated example.scala to pass the tests. I could not find pig latin rules that mentioned special case handling of 'xr' and 'yt' prefixes. So, I just got the tests to pass. There may be other rules that the example does not implement. The solution matches Haskell's solution...

Refs #370, #331