### PR TITLE
Create DominoesTestGenerator.scala. Update DominoesTest.scala. 

### DIFF
--- a/exercises/dominoes/src/main/scala/Dominoes.scala
+++ b/exercises/dominoes/src/main/scala/Dominoes.scala
@@ -1,4 +1,0 @@
-object Dominoes {
-
-  def chain(dominoes: List[(Int, Int)]): Option[List[(Int, Int)]] = ???
-}

--- a/exercises/dominoes/src/test/scala/DominoesTest.scala
+++ b/exercises/dominoes/src/test/scala/DominoesTest.scala
@@ -1,6 +1,35 @@
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{Matchers, FunSuite}
 
+/** @version 2.0.0 */
 class DominoesTest extends FunSuite with Matchers {
+
+  private def check(input: List[(Int, Int)], hasResult: Boolean): Unit = {
+    val result = Dominoes.chain(input)
+    if (hasResult) {
+      checkChain(result getOrElse fail("should have had a chain, but didn't"), input)
+    }
+    else assert(result == None)
+  }
+
+  private def checkChain(result: List[(Int, Int)], input: List[(Int, Int)]): Unit = {
+    def sortDomino(ab: (Int, Int)): (Int, Int) =
+      if (ab._1 > ab._2) ab.swap else ab
+    def consecutivesShouldMatch(dominoes: List[((Int, Int), Int)]): Unit =
+      dominoes.tails foreach {
+        case (a@(_,x), i1)::(b@(y,_), i2)::_ =>
+          assert(x == y, s"dominoes $i1 and $i2 don't match: $a $b")
+        case _ =>
+      }
+    def endsShouldMatch: Unit =
+      if (!result.isEmpty)
+        consecutivesShouldMatch(List((result.last, result.length - 1),
+          (result.head, 0)))
+
+    assert(result.map(sortDomino).sorted == input.map(sortDomino).sorted,
+      "doesn't consist of input dominoes")
+    consecutivesShouldMatch(result.zipWithIndex)
+    endsShouldMatch
+  }
 
   test("empty input = empty output") {
     check(List(), true)
@@ -56,36 +85,8 @@ class DominoesTest extends FunSuite with Matchers {
     check(List((1, 2), (2, 3), (3, 1), (1, 1), (2, 2), (3, 3)), true)
   }
 
-  test("ten elements") {
+  test("nine elements") {
     pending
     check(List((1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6)), true)
-  }
-
-  private def check(input: List[(Int, Int)], hasResult: Boolean): Unit = {
-    val result = Dominoes.chain(input)
-    if (hasResult) {
-      checkChain(result getOrElse fail("should have had a chain, but didn't"), input)
-    }
-    else assert(result == None)
-  }
-
-  private def checkChain(result: List[(Int, Int)], input: List[(Int, Int)]): Unit = {
-    def sortDomino(ab: (Int, Int)): (Int, Int) =
-      if (ab._1 > ab._2) ab.swap else ab
-    def consecutivesShouldMatch(dominoes: List[((Int, Int), Int)]): Unit =
-      dominoes.tails foreach {
-        case (a@(_,x), i1)::(b@(y,_), i2)::_ =>
-          assert(x == y, s"dominoes $i1 and $i2 don't match: $a $b")
-        case _ =>
-      }
-    def endsShouldMatch: Unit =
-      if (!result.isEmpty)
-        consecutivesShouldMatch(List((result.last, result.length - 1),
-                                     (result.head, 0)))
-
-    assert(result.map(sortDomino).sorted == input.map(sortDomino).sorted,
-        "doesn't consist of input dominoes")
-    consecutivesShouldMatch(result.zipWithIndex)
-    endsShouldMatch
   }
 }

--- a/testgen/src/main/scala/DominoesTestGenerator.scala
+++ b/testgen/src/main/scala/DominoesTestGenerator.scala
@@ -1,0 +1,71 @@
+import java.io.File
+
+import testgen.TestSuiteBuilder._
+import testgen._
+import play.twirl.api.Txt
+import play.twirl.api.Template1
+
+object DominoesTestGenerator {
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/dominoes.json")
+
+    def toString(expected: CanonicalDataParser.Expected): String = {
+      expected match {
+        case Left(_) => "false"
+        case Right(false) => "false"
+        case Right(true) => "true"
+      }
+    }
+
+    def sutArgs(parseResult: CanonicalDataParser.ParseResult, argNames: String*): String =
+      argNames map (name => toArgString(parseResult(name))) mkString ", "
+
+    def toArgString(any: Any): String = {
+      any match {
+        case xs: List[List[_]] => s"List(${xs.map(ys => s"(${ys.mkString(", ")})").mkString(", ")})"
+        case _ => any.toString
+      }
+    }
+
+    def fromLabeledTest(argNames: String*): ToTestCaseData =
+      withLabeledTest { sut =>
+        labeledTest =>
+          val args = sutArgs(labeledTest.result, argNames: _*)
+          val property = labeledTest.property
+          val expected = toString(labeledTest.expected)
+          val sutCall =
+            s"""check($args, $expected)"""
+          TestCaseData(labeledTest.description, sutCall, expected)
+      }
+
+    val template: TestSuiteTemplate =
+      txt.funSuiteTemplateIgnoreExpected.asInstanceOf[Template1[TestSuiteData, Txt]]
+
+    val code = TestSuiteBuilder.build(file, fromLabeledTest("input"), Seq(),
+      Seq("private def check(input: List[(Int, Int)], hasResult: Boolean): Unit = {",
+        "    val result = Dominoes.chain(input)", "    if (hasResult) {",
+        "      checkChain(result getOrElse fail(\"should have had a chain, but didn't\"), input)",
+        "    }", "    else assert(result == None)", "  }",
+        "",
+        "  private def checkChain(result: List[(Int, Int)], input: List[(Int, Int)]): Unit = {",
+        "    def sortDomino(ab: (Int, Int)): (Int, Int) =", "      if (ab._1 > ab._2) ab.swap else ab",
+        "    def consecutivesShouldMatch(dominoes: List[((Int, Int), Int)]): Unit =",
+        "      dominoes.tails foreach {",
+        "        case (a@(_,x), i1)::(b@(y,_), i2)::_ =>",
+        "          assert(x == y, s\"dominoes $i1 and $i2 don't match: $a $b\")",
+        "        case _ =>",
+        "      }",
+        "    def endsShouldMatch: Unit =",
+        "      if (!result.isEmpty)",
+        "        consecutivesShouldMatch(List((result.last, result.length - 1),",
+        "                                     (result.head, 0)))",
+        "",
+        "    assert(result.map(sortDomino).sorted == input.map(sortDomino).sorted,",
+        "        \"doesn't consist of input dominoes\")",
+        "    consecutivesShouldMatch(result.zipWithIndex)",
+        "    endsShouldMatch", "  }"))(template)
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}

--- a/testgen/src/main/twirl/funSuiteTemplateIgnoreExpected.scala.txt
+++ b/testgen/src/main/twirl/funSuiteTemplateIgnoreExpected.scala.txt
@@ -1,0 +1,16 @@
+@(data: testgen.TestSuiteData)@for(imp <- data.imports) {
+import @imp}
+
+import org.scalatest.{Matchers, FunSuite}
+@import testgen.TestSuiteBuilder._
+
+/** @@version @data.version */
+class @data.name extends FunSuite with Matchers {
+@for(statement <- data.statements) {
+  @statement}
+@for(testCase <- data.testCases) {
+  test("@testCase.description") { @if(testCase.pending) {
+    pending}
+    @testCase.sutCall
+  }
+}}


### PR DESCRIPTION
* Create DominoesTestGenerator.scala. 
* Update DominoesTest.scala. 
* Add template that allows tests to be generated that do not include `should be(_)`
* Remove empty implementation. Replace with .keep file.

Refs #370, #331