### PR TITLE
Create ClockTestGenerator.scala. Update ClockTest.scala. Refs #370, #331

### DIFF
--- a/exercises/clock/src/test/scala/ClockTest.scala
+++ b/exercises/clock/src/test/scala/ClockTest.scala
@@ -1,260 +1,254 @@
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{Matchers, FunSuite}
 
-class ClockTest extends FlatSpec with Matchers {
-  it should "construct from hour/min" in {
-    Clock(8, 0).toString should be ("08:00")
-    Clock(11, 9).toString should be ("11:09")
+/** @version 1.0.1 */
+class ClockTest extends FunSuite with Matchers {
+
+  test("on the hour") {
+    Clock(8, 0) should be (Clock(8, 0))
   }
 
-  it should "construct from minutes" in {
+  test("past the hour") {
     pending
-    Clock(3).toString should be ("00:03")
+    Clock(11, 9) should be (Clock(11, 9))
   }
 
-  it should "implement equals" in {
-    pending
-    Clock(15, 37) should be (Clock(15, 37))
-    Clock(15, 37) should not be Clock(15, 36)
-  }
-
-  it should "support wraparound" in {
+  test("midnight is zero hours") {
     pending
     Clock(24, 0) should be (Clock(0, 0))
+  }
+
+  test("hour rolls over") {
+    pending
     Clock(25, 0) should be (Clock(1, 0))
   }
 
-  it should "handle hour rolls over continuously" in {
+  test("hour rolls over continuously") {
     pending
     Clock(100, 0) should be (Clock(4, 0))
   }
 
-  it should "implement 60 min as the next hour" in {
+  test("sixty minutes is next hour") {
     pending
     Clock(1, 60) should be (Clock(2, 0))
   }
 
-  it should "construct consistently between constructors" in {
-    pending
-    Clock(60) should be (Clock(1, 0))
-  }
-
-  it should "support rolling over minutes" in {
+  test("minutes roll over") {
     pending
     Clock(0, 160) should be (Clock(2, 40))
   }
 
-  it should "handle minutes rolling over consistently" in {
+  test("minutes roll over continuously") {
     pending
     Clock(0, 1723) should be (Clock(4, 43))
   }
 
-  it should "support rolling over both hours and minutes" in {
+  test("hour and minutes roll over") {
     pending
     Clock(25, 160) should be (Clock(3, 40))
   }
 
-  it should "handle hours and minutes rolling over consistently" in {
+  test("hour and minutes roll over continuously") {
     pending
     Clock(201, 3001) should be (Clock(11, 1))
   }
 
-  it should "handle hours and minutes rolling over to midnight" in {
+  test("hour and minutes roll over to exactly midnight") {
     pending
     Clock(72, 8640) should be (Clock(0, 0))
   }
 
-  it should "handle negative hour" in {
+  test("negative hour") {
     pending
     Clock(-1, 15) should be (Clock(23, 15))
   }
 
-  it should "handle rolling over negative hour" in {
+  test("negative hour rolls over") {
     pending
     Clock(-25, 0) should be (Clock(23, 0))
   }
 
-  it should "handle negative hours rolling over consistently" in {
+  test("negative hour rolls over continuously") {
     pending
     Clock(-91, 0) should be (Clock(5, 0))
   }
 
-  it should "handle negative minute" in {
+  test("negative minutes") {
     pending
     Clock(1, -40) should be (Clock(0, 20))
   }
 
-  it should "handle rolling over negative minute" in {
+  test("negative minutes roll over") {
     pending
     Clock(1, -160) should be (Clock(22, 20))
   }
 
-  it should "handle negative minutes rolling over consistently" in {
+  test("negative minutes roll over continuously") {
     pending
     Clock(1, -4820) should be (Clock(16, 40))
   }
 
-  it should "handle negative hour and minutes roll over" in {
+  test("negative hour and minutes both roll over") {
     pending
     Clock(-25, -160) should be (Clock(20, 20))
   }
 
-  it should "handle negative hour and minutes rolling over consistently" in {
+  test("negative hour and minutes both roll over continuously") {
     pending
     Clock(-121, -5810) should be (Clock(22, 10))
   }
 
-  it should "add minutes" in {
+  test("add minutes") {
     pending
     Clock(10, 0) + Clock(3) should be (Clock(10, 3))
   }
 
-  it should "add no minutes" in {
+  test("add no minutes") {
     pending
     Clock(6, 41) + Clock(0) should be (Clock(6, 41))
   }
 
-  it should "add to next hour" in {
+  test("add to next hour") {
     pending
     Clock(0, 45) + Clock(40) should be (Clock(1, 25))
   }
 
-  it should "add more than one hour" in {
+  test("add more than one hour") {
     pending
     Clock(10, 0) + Clock(61) should be (Clock(11, 1))
   }
 
-  it should "add more than two hours with carry" in {
+  test("add more than two hours with carry") {
     pending
     Clock(0, 45) + Clock(160) should be (Clock(3, 25))
   }
 
-  it should "add across midnight" in {
+  test("add across midnight") {
     pending
     Clock(23, 59) + Clock(2) should be (Clock(0, 1))
   }
 
-  it should "add more than one day (1500 min == 25 hours)" in {
+  test("add more than one day (1500 min = 25 hrs)") {
     pending
     Clock(5, 32) + Clock(1500) should be (Clock(6, 32))
   }
 
-  it should "add more than 2 days" in {
+  test("add more than two days") {
     pending
     Clock(1, 1) + Clock(3500) should be (Clock(11, 21))
   }
 
-  it should "subtract minutes" in {
+  test("subtract minutes") {
     pending
     Clock(10, 3) - Clock(3) should be (Clock(10, 0))
   }
 
-  it should "subtract to previous hour" in {
+  test("subtract to previous hour") {
     pending
     Clock(10, 3) - Clock(30) should be (Clock(9, 33))
   }
 
-  it should "subtract more than an hour" in {
+  test("subtract more than an hour") {
     pending
     Clock(10, 3) - Clock(70) should be (Clock(8, 53))
   }
 
-  it should "subtract across midnight" in {
+  test("subtract across midnight") {
     pending
     Clock(0, 3) - Clock(4) should be (Clock(23, 59))
   }
 
-  it should "subtract more than two hours" in {
+  test("subtract more than two hours") {
     pending
     Clock(0, 0) - Clock(160) should be (Clock(21, 20))
   }
 
-  it should "subtract more than two hours with borrow" in {
+  test("subtract more than two hours with borrow") {
     pending
     Clock(6, 15) - Clock(160) should be (Clock(3, 35))
   }
 
-  it should "subtract more than one day (1500 min = 25 hrs)" in {
+  test("subtract more than one day (1500 min = 25 hrs)") {
     pending
     Clock(5, 32) - Clock(1500) should be (Clock(4, 32))
   }
 
-  it should "subtract more than two days" in {
+  test("subtract more than two days") {
     pending
     Clock(2, 20) - Clock(3000) should be (Clock(0, 20))
   }
 
-  it should "handle equality of clocks with same time" in {
+  test("clocks with same time") {
     pending
-    Clock(15, 37) should be (Clock(15, 37))
+    Clock(15, 37) == Clock(15, 37) should be (true)
   }
 
-  it should "handle equality of clocks that are one minute apart" in {
+  test("clocks a minute apart") {
     pending
-    Clock(15, 36) should not be (Clock(15, 37))
+    Clock(15, 36) == Clock(15, 37) should be (false)
   }
 
-  it should "handle equality of clocks that are one hour apart" in {
+  test("clocks an hour apart") {
     pending
-    Clock(14, 37) should not be (Clock(15, 37))
+    Clock(14, 37) == Clock(15, 37) should be (false)
   }
 
-  it should "handle equality of clocks with hour overflow" in {
+  test("clocks with hour overflow") {
     pending
-    Clock(10, 37) should be (Clock(34, 37))
+    Clock(10, 37) == Clock(34, 37) should be (true)
   }
 
-  it should "handle equality of clocks with hour overflow by several days" in {
+  test("clocks with hour overflow by several days") {
     pending
-    Clock(3, 11) should be (Clock(99, 11))
+    Clock(3, 11) == Clock(99, 11) should be (true)
   }
 
-  it should "handle equality of clocks with negative hour" in {
+  test("clocks with negative hour") {
     pending
-    Clock(22, 40) should be (Clock(-2, 40))
+    Clock(22, 40) == Clock(-2, 40) should be (true)
   }
 
-  it should "handle equality of clocks with negative hour that wraps" in {
+  test("clocks with negative hour that wraps") {
     pending
-    Clock(17, 3) should be (Clock(-31, 3))
+    Clock(17, 3) == Clock(-31, 3) should be (true)
   }
 
-  it should "handle equality of clocks with negative hour that wraps multiple times" in {
+  test("clocks with negative hour that wraps multiple times") {
     pending
-    Clock(13, 49) should be (Clock(-83, 49))
+    Clock(13, 49) == Clock(-83, 49) should be (true)
   }
 
-  it should "handle equality of clocks with minute overflow" in {
+  test("clocks with minute overflow") {
     pending
-    Clock(0, 1) should be (Clock(0, 1441))
+    Clock(0, 1) == Clock(0, 1441) should be (true)
   }
 
-  it should "handle equality of clocks with minute overflow by several days" in {
+  test("clocks with minute overflow by several days") {
     pending
-    Clock(2, 2) should be (Clock(2, 4322))
+    Clock(2, 2) == Clock(2, 4322) should be (true)
   }
 
-  it should "handle equality of clocks with negative minute" in {
+  test("clocks with negative minute") {
     pending
-    Clock(2, 40) should be (Clock(3, -20))
+    Clock(2, 40) == Clock(3, -20) should be (true)
   }
 
-  it should "handle equality of clocks with negative minute that wraps" in {
+  test("clocks with negative minute that wraps") {
     pending
-    Clock(4, 10) should be (Clock(5, -1490))
+    Clock(4, 10) == Clock(5, -1490) should be (true)
   }
 
-  it should "handle equality of clocks with negative minute that wraps mutiple times" in {
+  test("clocks with negative minute that wraps multiple times") {
     pending
-    Clock(6, 15) should be (Clock(6, -4305))
+    Clock(6, 15) == Clock(6, -4305) should be (true)
   }
 
-  it should "handle equality of clocks with negative hours and minute" in {
+  test("clocks with negative hours and minutes") {
     pending
-    Clock(7, 32) should be (Clock(-12, -268))
+    Clock(7, 32) == Clock(-12, -268) should be (true)
   }
 
-  it should "handle equality of clocks with negative hours and minute that wrap" in {
+  test("clocks with negative hours and minutes that wrap") {
     pending
-    Clock(18, 7) should be (Clock(-54, -11513))
+    Clock(18, 7) == Clock(-54, -11513) should be (true)
   }
 }

--- a/testgen/src/main/scala/ClockTestGenerator.scala
+++ b/testgen/src/main/scala/ClockTestGenerator.scala
@@ -1,0 +1,66 @@
+import java.io.File
+
+import testgen.TestSuiteBuilder.{toString, _}
+import testgen._
+
+object ClockTestGenerator {
+  private def toString(expected: CanonicalDataParser.Expected): String =
+    expected.fold(_ => "", TestSuiteBuilder.toString)
+
+  private def expectedToClockStr(expected: CanonicalDataParser.Expected): String =
+    expected.fold(_ => "", any => any match {
+      case str: String => str.split(':').map(_.toInt).mkString(", ")
+      case _ => throw new IllegalArgumentException
+    })
+
+  private def toOperation(addArg: String): String =
+    if (addArg.startsWith("-")) "-" else "+"
+
+  def mapArgToStringForEqual(arg: Any): String = {
+    arg match {
+      case vals: Map[String, String] => s"${vals("hour")}, ${vals("minute")}"
+      case _ => throw new IllegalArgumentException
+    }
+  }
+
+  def sutArgsForEqual(parseResult: CanonicalDataParser.ParseResult, argNames: String*): String =
+    argNames map (name => mapArgToStringForEqual(parseResult(name))) mkString
+
+  def fromLabeledTestAlt(propArgs: (String, Seq[String])*): ToTestCaseData =
+    withLabeledTest { sut => labeledTest =>
+      val sutFunction = labeledTest.property
+      val args = sutArgsAlt(labeledTest.result, propArgs:_*)
+
+      val sutCall =
+        if (sutFunction.toString == "create")
+          s"$sut($args)"
+        else if (sutFunction.toString == "add") {
+          val addArgs = sutArgs(labeledTest.result, "add")
+          s"$sut($args) ${toOperation(addArgs)} $sut(${addArgs.stripPrefix("-")})"
+        } else {
+          val argsForEqual1 = sutArgsForEqual(labeledTest.result, "clock1")
+          val argsForEqual2 = sutArgsForEqual(labeledTest.result, "clock2")
+          s"$sut($argsForEqual1) == $sut($argsForEqual2)"
+        }
+
+      val expected =
+        if (sutFunction.toString == "create" || sutFunction.toString == "add")
+          s"$sut(${expectedToClockStr(labeledTest.expected)})"
+        else
+          toString(labeledTest.expected)
+
+      TestCaseData(s"${labeledTest.description}", sutCall, expected)
+    }
+
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/clock.json")
+
+    val code = TestSuiteBuilder.build(file,
+      fromLabeledTestAlt("create" -> Seq("hour", "minute"),
+        "add" -> Seq("hour", "minute"),
+        "equal" -> Seq("clock1")))
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}


### PR DESCRIPTION
* Create ClockTestGenerator.scala. 
* Update ClockTest.scala.

Note that I don't really like the equals test cases testing for true/false. Instead the code should be rewritten to look like - 
`Clock(13, 49)  should be (Clock(-83, 49))`
and 
`Clock(15, 36) should not be (Clock(15, 37))`
But, I have not figured out a clean way to implement.

 Refs #370, #331