### PR TITLE
Add VersionCheck tool. Refs #370, #331

### DIFF
--- a/testgen/src/main/resources/version-check-ignore.txt
+++ b/testgen/src/main/resources/version-check-ignore.txt
@@ -1,0 +1,5 @@
+binary
+hexadecimal
+octal
+trinary
+meetup

--- a/testgen/src/main/scala/VersionCheck.scala
+++ b/testgen/src/main/scala/VersionCheck.scala
@@ -1,0 +1,72 @@
+import java.io.File
+
+import testgen.{CanonicalDataParser, Exercise}
+
+import scala.io.Source
+
+/**
+ * Tool to verify implemented version of exercises vs the canonical version.
+ * The scala project and the problem-specifications project should be
+ * pulled before running this tool.
+ */
+object VersionCheck {
+  private def getImplementedVersion(file: File): String = {
+    val prefix = "/** @version "
+    val suffix1 = " */"
+    val suffix2 = " **/"
+    val versionLine = Source.fromFile(file).getLines
+      .find(l => l.startsWith(prefix))
+    versionLine match {
+      case Some(l) =>
+        l.stripPrefix(prefix)
+          .stripSuffix(suffix1)
+          .stripSuffix(suffix2)
+      case None => "No version in file"
+    }
+  }
+
+  private def getCanonicalVersion(file: File): String = {
+    val exercise @ Exercise(name, version, cases, comments) =
+      CanonicalDataParser.parse(file)
+    version
+  }
+
+  private def getCanonicaDataPath(exerciseName: String,
+                                  problemSpecDir: String): File =
+    new File(new File(problemSpecDir, exerciseName), "canonical-data.json")
+
+  private val ignoreExercises: Set[String] =
+    Source.fromFile(new File("./src/main/resources/version-check-ignore.txt")).getLines.toSet
+
+  def main(args: Array[String]): Unit = {
+    if (args.length != 1) {
+      println("Usage VersionCheck /path/ where path is the filesystem path to the problem-specifications exercises directory.")
+      System.exit(-1)
+    }
+
+    val problemSpecDir = args.head
+
+    val exerciseDirs = new File("../exercises").listFiles()
+      .toList
+      .filter(f => f.isDirectory)
+      .filter(f => !ignoreExercises.contains(f.getName))
+      .sorted
+
+    exerciseDirs.foreach(f => {
+      new File(f, "src/test/scala").listFiles()
+        .toList
+        .filter(testFile => testFile.getName.endsWith("Test.scala")) match {
+        case x::_ =>
+          val implementedVersion = getImplementedVersion(x)
+          val canonicalDataPath = getCanonicaDataPath(f.getName, problemSpecDir)
+          if (canonicalDataPath.exists()) {
+            val canonicalVersion = getCanonicalVersion(canonicalDataPath)
+            if (!implementedVersion.equals(canonicalVersion)) {
+              println(s"${f.getName}\timplemented version - $implementedVersion\tcanonical version - $canonicalVersion")
+            }
+          }
+        case _ =>
+      }
+    })
+  }
+}


### PR DESCRIPTION
This is a simple tool to compare the version of the unit test against the canonical-data.json. If there is a version mismatch info is printed to the console.

Exercises can be excluded from checking by including the exercise name in `testgen/src/main/resources/version-check-ignore.txt`. Each excluded line should be placed on a separate line.

Note that there isn't much in the way of error checking or robustness features in the tool. And, I have only tested it on macOS. I didn't take much care in dealing with OS dir separators.