### PR TITLE
Remove meetup from version-check-ignore. Refs #370

### DIFF
--- a/testgen/src/main/resources/version-check-ignore.txt
+++ b/testgen/src/main/resources/version-check-ignore.txt
@@ -2,4 +2,3 @@ binary
 hexadecimal
 octal
 trinary
-meetup


### PR DESCRIPTION
No need for meetup to be in version-check-ignore now that there is a test generator.