### PR TITLE
Inline the exercise README insert

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,10 +4,16 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
-{{- with .Spec.Credits -}}
+The Scala exercises assume an SBT project scheme. The exercise solution source
+should be placed within the exercise directory/src/main/scala. The exercise
+unit tests can be found within the exercise directory/src/test/scala.
+
+To run the tests simply run the command `sbt test` in the exercise directory.
+
+For more detailed info about the Scala track see the [help
+page](http://exercism.io/languages/scala).
+
+{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -1,9 +1,0 @@
-The Scala exercises assume an SBT project scheme. The exercise solution source
-should be placed within the exercise directory/src/main/scala. The exercise
-unit tests can be found within the exercise directory/src/test/scala.
-
-To run the tests simply run the command `sbt test` in the exercise directory.
-
-For more detailed info about the Scala track see the [help
-page](http://exercism.io/languages/scala).
-

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -25,9 +25,6 @@ Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
 
-Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
-as this is idiomatic Lisp, not a library function.
-
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise
 unit tests can be found within the exercise directory/src/test/scala.

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -7,7 +7,6 @@ Techies love their TLA (Three Letter Acronyms)!
 Help generate some jargon by writing a program that converts a long name
 like Portable Network Graphics to its acronym (PNG).
 
-
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise
 unit tests can be found within the exercise directory/src/test/scala.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -6,6 +6,7 @@ Implement general base conversion. Given a number in base **a**,
 represented as a sequence of digits, convert it to base **b**.
 
 ## Note
+
 - Try to implement the conversion yourself.
   Do not use something else to perform the conversion for you.
 
@@ -27,7 +28,6 @@ The number 1120, *in base 3*, means:
 (1 * 3^3) + (1 * 3^2) + (2 * 3^1) + (0 * 3^0)
 
 I think you got the idea!
-
 
 *Yes. Those three numbers above are exactly the same. Congratulations!*
 

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -41,6 +41,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -29,7 +29,6 @@ allergens that score 256, 512, 1024, etc.).  Your program should
 ignore those components of the score.  For example, if the allergy
 score is 257, your program should only report the eggs (1) allergy.
 
-
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise
 unit tests can be found within the exercise directory/src/test/scala.

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -7,7 +7,7 @@ letters in words are replaced with numbers.
 
 For example `SEND + MORE = MONEY`:
 
-```
+```text
   S E N D
   M O R E +
 -----------
@@ -16,7 +16,7 @@ M O N E Y
 
 Replacing these with valid numbers gives:
 
-```
+```text
   9 5 6 7
   1 0 8 5 +
 -----------

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -41,6 +41,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -9,7 +9,7 @@ letter, the second with the second-last, and so on.
 
 An Atbash cipher for the Latin alphabet would be as follows:
 
-```plain
+```text
 Plain:  abcdefghijklmnopqrstuvwxyz
 Cipher: zyxwvutsrqponmlkjihgfedcba
 ```
@@ -23,6 +23,7 @@ being 5 letters, and punctuation is excluded. This is to make it harder to guess
 things based on word boundaries.
 
 ## Examples
+
 - Encoding `test` gives `gvhg`
 - Decoding `gvhg` gives `test`
 - Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -49,6 +49,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,10 +1,10 @@
 # Beer Song
 
-Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+Recite the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
 
 Note that not all verses are identical.
 
-```plain
+```text
 99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -7,10 +7,12 @@ string, your program should produce a decimal output. The
 program should handle invalid inputs.
 
 ## Note
+
 - Implement the conversion yourself.
   Do not use something else to perform the conversion for you.
 
 ## About Binary (Base-2)
+
 Decimal is a base-10 system.
 
 A number 23 in base 10 notation can be understood

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -3,20 +3,20 @@
 To try and encourage more sales of different books from a popular 5 book
 series, a bookshop has decided to offer discounts on multiple book purchases.
 
-One copy of any of the five books costs $8. 
+One copy of any of the five books costs $8.
 
 If, however, you buy two different books, you get a 5%
 discount on those two books.
 
-If you buy 3 different books, you get a 10% discount. 
+If you buy 3 different books, you get a 10% discount.
 
 If you buy 4 different books, you get a 20% discount.
 
-If you buy all 5, you get a 25% discount. 
+If you buy all 5, you get a 25% discount.
 
 Note: that if you buy four books, of which 3 are
 different titles, you get a 10% discount on the 3 that
-form part of a set, but the fourth book still costs $8. 
+form part of a set, but the fourth book still costs $8.
 
 Your mission is to write a piece of code to calculate the
 price of any conceivable shopping basket (containing only
@@ -30,7 +30,7 @@ For example, how much does this basket of books cost?
 - 2 copies of the third book
 - 1 copy of the fourth book
 - 1 copy of the fifth book
- 
+
 One way of grouping these 8 books is:
 
 - 1 group of 5 --> 25% discount (1st,2nd,3rd,4th,5th)

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -2,19 +2,29 @@
 
 Score a bowling game.
 
-Bowling is game where players roll a heavy ball to knock down pins
+Bowling is a game where players roll a heavy ball to knock down pins
 arranged in a triangle. Write code to keep track of the score
 of a game of bowling.
 
 ## Scoring Bowling
 
-The game consists of 10 frames. A frame is composed of one or two ball throws with 10 pins standing at frame initialization. There are three cases for the tabulation of a frame.
+The game consists of 10 frames. A frame is composed of one or two ball
+throws with 10 pins standing at frame initialization. There are three
+cases for the tabulation of a frame.
 
-* An open frame is where a score of less than 10 is recorded for the frame. In this case the score for the frame is the number of pins knocked down.
+* An open frame is where a score of less than 10 is recorded for the
+  frame. In this case the score for the frame is the number of pins
+  knocked down.
 
-* A spare is where all ten pins are knocked down after the second throw. The total value of a spare is 10 plus the number of pins knocked down in their next throw.
+* A spare is where all ten pins are knocked down by the second
+  throw. The total value of a spare is 10 plus the number of pins
+  knocked down in their next throw.
 
-* A strike is where all ten pins are knocked down after the first throw. The total value of a strike is 10 plus the number of pins knocked down in their next two throws. If a strike is immediately followed by a second strike, then we can not total the value of first strike until they throw the ball one more time.
+* A strike is where all ten pins are knocked down by the first
+  throw. The total value of a strike is 10 plus the number of pins
+  knocked down in the next two throws. If a strike is immediately
+  followed by a second strike, then the value of the first strike
+  cannot be determined until the ball is thrown one more time.
 
 Here is a three frame example:
 
@@ -30,7 +40,11 @@ Frame 3 is (9 + 0) = 9
 
 This means the current running total is 48.
 
-The tenth frame in the game is a special case. If someone throws a strike or a spare then they get a fill ball. Fill balls exist to calculate the total of the 10th frame. Scoring a strike or spare on the fill ball does not give the player more fill balls. The total value of the 10th frame is the total number of pins knocked down.
+The tenth frame in the game is a special case. If someone throws a
+strike or a spare then they get a fill ball. Fill balls exist to
+calculate the total of the 10th frame. Scoring a strike or spare on
+the fill ball does not give the player more fill balls. The total
+value of the 10th frame is the total number of pins knocked down.
 
 For a tenth frame of X1/ (strike and a spare), the total value is 20.
 

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -28,7 +28,7 @@ page](http://exercism.io/languages/scala).
 
 ## Source
 
-Software Craftsmanship - Kata-logue [http://craftsmanship.sv.cmu.edu/exercises/coin-change-kata](http://craftsmanship.sv.cmu.edu/exercises/coin-change-kata)
+Software Craftsmanship - Coin Change Kata [https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata](https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -1,4 +1,4 @@
-## Collatz Conjecture.
+# Collatz Conjecture
 
 The Collatz Conjecture or 3x+1 problem can be summarized as follows:
 
@@ -10,6 +10,7 @@ always reach 1 eventually.
 Given a number n, return the number of steps required to reach 1.
 
 ## Examples
+
 Starting with n = 12, the steps would be as follows:
 
 0. 12
@@ -34,10 +35,10 @@ To run the tests simply run the command `sbt test` in the exercise directory.
 For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
+
 ## Source
 
-An unsolved problem in mathematics named after mathematician Lothar Collatz
-see more at [collatz conjecture wikipedia](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
+An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -18,7 +18,7 @@ computes the winner (or lack thereof). Note that all games need not be "fair".
 The boards look like this (with spaces added for readability, which won't be in
 the representation passed to your code):
 
-```        
+```text
 . O . X .
  . X X O .
   O O O X .

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -48,6 +48,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -26,7 +26,7 @@ and `r` is the number of rows.
 Our normalized text is 54 characters long, dictating a rectangle with
 `c = 8` and `r = 7`:
 
-```plain
+```text
 ifmanwas
 meanttos
 tayonthe
@@ -41,22 +41,24 @@ right.
 
 The message above is coded as:
 
-```plain
+```text
 imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
 ```
 
-Output the encoded text in chunks.  Phrases that fill perfect squares
-`(r X r)` should be output in `r`-length chunks separated by spaces.
-Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+Output the encoded text in chunks.  Phrases that fill perfect rectangles
+`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
+Phrases that do not fill perfect rectangles will have `n` empty spaces.
+Those spaces should be distributed evenly, added to the end of the last
+`n` chunks.
 
-```plain
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+```text
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
 ```
 
 Notice that were we to stack these, we could visually decode the
 cyphertext back in to the original message:
 
-```plain
+```text
 imtgdvs
 fearwer
 mayoogo

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -17,6 +17,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -7,10 +7,10 @@ correct domino chain (the dots on one half of a stone match the dots on the
 neighbouring half of an adjacent stone) and that dots on the halfs of the stones
 which don't have a neighbour (the first and last stone) match each other.
 
-For example given the stones `21`, `23` and `13` you should compute something
-like `12 23 31` or `32 21 13` or `13 32 21` etc, where the first and last numbers are the same.
+For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
+like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.
 
-For stones 12, 41 and 23 the resulting chain is not valid: 41 12 23's first and last numbers are not the same. 4 != 3
+For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same. 4 != 3
 
 Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.
 

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -24,6 +24,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,8 +1,9 @@
-# Etl
+# ETL
 
 We are going to do the `Transform` step of an Extract-Transform-Load.
 
 ### ETL
+
 Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
 we're going to migrate this."
 
@@ -11,6 +12,7 @@ once." That's then typically followed by much forehead slapping and
 moaning about how stupid we could possibly be.)
 
 ### The goal
+
 We're going to extract some scrabble scores from a legacy system.
 
 The old system stored a list of letters per score:

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -10,16 +10,15 @@ input: [1,[2,3,null,4],[null],5]
 
 output: [1,2,3,4,5]
 
-Do not use scala built-in `flatten` function.
+The Scala exercises assume an SBT project scheme. The exercise solution source
+should be placed within the exercise directory/src/main/scala. The exercise
+unit tests can be found within the exercise directory/src/test/scala.
 
-## Submitting Exercises
+To run the tests simply run the command `sbt test` in the exercise directory.
 
-Note that, when trying to submit an exercise, make sure the solution is in the `exercism/scala/<exerciseName>` directory.
+For more detailed info about the Scala track see the [help
+page](http://exercism.io/languages/scala).
 
-For example, if you're submitting `FlattenArray.scala` for the Bob exercise, the submit command would be something like `exercism submit <path_to_exercism_dir>/src/main/scala/FlattenArray.scala`.
-
-For more detailed information about running tests, code style and linting,
-please see the [help page](http://exercism.io/languages/scala).
 
 ## Source
 

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -10,7 +10,7 @@ This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of unk
 
 This is one of many common variants.
 
-```plain
+```text
 I know an old lady who swallowed a fly.
 I don't know why she swallowed the fly. Perhaps she'll die.
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -35,6 +35,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -21,7 +21,6 @@ In the end, you should be able to:
 Note that all our students only have one name.  (It's a small town, what
 do you want?)
 
-
 ## For bonus points
 
 Did you get the tests passing and the code clean? If you want to, these

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -15,7 +15,6 @@ Write code that shows:
 - how many grains were on each square, and
 - the total number of grains
 
-
 ## For bonus points
 
 Did you get the tests passing and the code clean? If you want to, these

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -1,6 +1,6 @@
 # House
 
-Output the nursery rhyme 'This is the House that Jack Built'.
+Recite the nursery rhyme 'This is the House that Jack Built'.
 
 > [The] process of placing a phrase of clause within another phrase of
 > clause is called embedding. It is through the processes of recursion
@@ -11,10 +11,9 @@ Output the nursery rhyme 'This is the House that Jack Built'.
 
 - [papyr.com](http://papyr.com/hypertextbooks/grammar/ph_noun.htm)
 
-
 The nursery rhyme reads as follows:
 
-```plain
+```text
 This is the house that Jack built.
 
 This is the malt

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -2,13 +2,14 @@
 
 Determine if a word or phrase is an isogram.
 
-An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter.
+An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter, however spaces and hyphens are allowed to appear multiple times.
 
 Examples of isograms:
 
 - lumberjacks
 - background
 - downstream
+- six-year-old
 
 The word *isograms*, however, is not an isogram, because the s repeats.
 

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -3,19 +3,19 @@
 Given a diagram, determine which plants each child in the kindergarten class is
 responsible for.
 
-The kindergarten class is learning about growing plants. The teachers
+The kindergarten class is learning about growing plants. The teacher
 thought it would be a good idea to give them actual seeds, plant them in
 actual dirt, and grow actual plants.
 
 They've chosen to grow grass, clover, radishes, and violets.
 
-To this end, they've put little styrofoam cups along the window sills,
-and planted one type of plant in each cup, choosing randomly from the
-available types of seeds.
+To this end, the children have put little cups along the window sills, and
+planted one type of plant in each cup, choosing randomly from the available
+types of seeds.
 
-```plain
+```text
 [window][window][window]
-........................ # each dot represents a styrofoam cup
+........................ # each dot represents a cup
 ........................
 ```
 
@@ -25,27 +25,27 @@ There are 12 children in the class:
 - Eve, Fred, Ginny, Harriet,
 - Ileana, Joseph, Kincaid, and Larry.
 
-Each child gets 4 cups, two on each row. The children are assigned to
-cups in alphabetical order.
+Each child gets 4 cups, two on each row. Their teacher assigns cups to
+the children alphabetically by their names.
 
 The following diagram represents Alice's plants:
 
-```plain
+```text
 [window][window][window]
 VR......................
 RG......................
 ```
 
-So in the row nearest the window, she has a violet and a radish; in the
-row behind that, she has a radish and some grass.
+In the first row, nearest the windows, she has a violet and a radish.  In the
+second row she has a radish and some grass.
 
 Your program will be given the plants from left-to-right starting with
 the row nearest the windows. From this, it should be able to determine
-which plants belong to which students.
+which plants belong to each student.
 
 For example, if it's told that the garden looks like so:
 
-```plain
+```text
 [window][window][window]
 VRCGVVRVCGGCCGVRGCVCGCGV
 VRCCCGCRRGVCGCRVVCVGCGCV

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -4,7 +4,7 @@ Given a year, report if it is a leap year.
 
 The tricky thing here is that a leap year in the Gregorian calendar occurs:
 
-```plain
+```text
 on every year that is evenly divisible by 4
   except every year that is evenly divisible by 100
     unless the year is also evenly divisible by 400

--- a/exercises/lens-person/README.md
+++ b/exercises/lens-person/README.md
@@ -5,7 +5,7 @@ Use lenses to update nested records (specific to languages with immutable data).
 Updating fields of nested records is kind of annoying in Haskell. One solution
 is to use [lenses](https://wiki.haskell.org/Lens).  Implement several record
 accessing functions using lenses, you may use any library you want. The test
-suite also allows you to avoid lenses alltogether so you can experiment with
+suite also allows you to avoid lenses altogether so you can experiment with
 different approaches.
 
 The Scala exercises assume an SBT project scheme. The exercise solution source

--- a/exercises/lens-person/README.md
+++ b/exercises/lens-person/README.md
@@ -18,6 +18,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -2,18 +2,18 @@
 
 Implement a doubly linked list.
 
-Like an array, a linked list is a simple linear data structure. Several 
-common data types can be implemented using linked lists, like queues, 
+Like an array, a linked list is a simple linear data structure. Several
+common data types can be implemented using linked lists, like queues,
 stacks, and associative arrays.
 
-A linked list is a collection of data elements called *nodes*. In a 
-*singly linked list* each node holds a value and a link to the next node. 
-In a *doubly linked list* each node also holds a link to the previous 
+A linked list is a collection of data elements called *nodes*. In a
+*singly linked list* each node holds a value and a link to the next node.
+In a *doubly linked list* each node also holds a link to the previous
 node.
 
-You will write an implementation of a doubly linked list. Implement a 
-Node to hold a value and pointers to the next and previous nodes. Then 
-implement a List which holds references to the first and last node and 
+You will write an implementation of a doubly linked list. Implement a
+Node to hold a value and pointers to the next and previous nodes. Then
+implement a List which holds references to the first and last node and
 offers an array-like interface for adding and removing items:
 
 * `push` (*insert value at back*);
@@ -21,8 +21,8 @@ offers an array-like interface for adding and removing items:
 * `shift` (*remove value at front*).
 * `unshift` (*insert value at front*);
 
-To keep your implementation simple, the tests will not cover error 
-conditions. Specifically: `pop` or `shift` will never be called on an 
+To keep your implementation simple, the tests will not cover error
+conditions. Specifically: `pop` or `shift` will never be called on an
 empty list.
 
 If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -18,27 +18,27 @@ are disallowed.
 
 ## Example 1: valid credit card number
 
-```
+```text
 4539 1488 0343 6467
 ```
 
 The first step of the Luhn algorithm is to double every second digit,
 starting from the right. We will be doubling
 
-```
+```text
 4_3_ 1_8_ 0_4_ 6_6_
 ```
 
 If doubling the number results in a number greater than 9 then subtract 9
 from the product. The results of our doubling:
 
-```
+```text
 8569 2478 0383 3437
 ```
 
 Then sum all of the digits:
 
-```
+```text
 8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
 ```
 
@@ -46,19 +46,19 @@ If the sum is evenly divisible by 10, then the number is valid. This number is v
 
 ## Example 2: invalid credit card number
 
-```
+```text
 8273 1232 7352 0569
 ```
 
 Double the second digits, starting from the right
 
-```
+```text
 7253 2262 5312 0539
 ```
 
 Sum the digits
 
-```
+```text
 7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
 ```
 

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -5,13 +5,15 @@ that matrix.
 
 So given a string with embedded newlines like:
 
-> 9 8 7  
-> 5 3 2  
-> 6 6 7  
+```text
+9 8 7
+5 3 2
+6 6 7
+```
 
 representing this matrix:
 
-```plain
+```text
     0  1  2
   |---------
 0 | 9  8  7

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -2,26 +2,29 @@
 
 Calculate the date of meetups.
 
-Typically meetups happen on the same day of the week.  In this exercise, you will take
-a description of a meetup date, and return the actual meetup date.
+Typically meetups happen on the same day of the week.  In this exercise, you
+will take a description of a meetup date, and return the actual meetup date.
 
 Examples of general descriptions are:
 
-- the first Monday of January 2017
-- the third Tuesday of January 2017
-- the Wednesteenth of January 2017
-- the last Thursday of January 2017
+- The first Monday of January 2017
+- The third Tuesday of January 2017
+- The wednesteenth of January 2017
+- The last Thursday of January 2017
 
-Note that "Monteenth", "Tuesteenth", etc are all made up words. There
-was a meetup whose members realized that there are exactly 7 numbered days in a month that
-end in '-teenth'. Therefore, one is guaranteed that each day of the week
+The descriptors you are expected to parse are:
+first, second, third, fourth, fifth, last, monteenth, tuesteenth, wednesteenth,
+thursteenth, friteenth, saturteenth, sunteenth
+
+Note that "monteenth", "tuesteenth", etc are all made up words. There was a
+meetup whose members realized that there are exactly 7 numbered days in a month
+that end in '-teenth'. Therefore, one is guaranteed that each day of the week
 (Monday, Tuesday, ...) will have exactly one date that is named with '-teenth'
 in every month.
 
-Given examples of a meetup dates, each containing a month, day, year, and descriptor 
-(first, second, teenth, etc), calculate the date of the actual meetup.
-For example, if given "First Monday of January 2017", the correct meetup date is 2017/1/2
- 
+Given examples of a meetup dates, each containing a month, day, year, and
+descriptor calculate the date of the actual meetup.  For example, if given
+"The first Monday of January 2017", the correct meetup date is 2017/1/2.
 
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -36,6 +36,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,30 +1,16 @@
 # Nucleotide Count
 
-Given a DNA string, compute how many times each nucleotide occurs in the string.
+Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
 
-DNA is represented by an alphabet of the following symbols: 'A', 'C',
-'G', and 'T'.
+The genetic language of every living thing on the planet is DNA.
+DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
+4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
 
-Each symbol represents a nucleotide, which is a fancy name for the
-particular molecules that happen to make up a large part of DNA.
-
-Shortest intro to biochemistry EVAR:
-
+Here is an analogy:
 - twigs are to birds nests as
-- nucleotides are to DNA and RNA as
-- amino acids are to proteins as
-- sugar is to starch as
-- oh crap lipids
-
-I'm not going to talk about lipids because they're crazy complex.
-
-So back to nucleotides.
-
-DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
-(`G`), and thymine (`T`).
-
-RNA contains a slightly different set of nucleotides, but we don't care
-about that for now.
+- nucleotides are to DNA as
+- legos are to lego houses as
+- words are to sentences as...
 
 ## Hints
 A common use of `Either` is to indicate a computation that may possibly result in an error

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -1,4 +1,4 @@
-# Ocr Numbers
+# OCR Numbers
 
 Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
 represented, or whether it is garbled.
@@ -9,7 +9,7 @@ To begin with, convert a simple binary font to a string containing 0 or 1.
 
 The binary font uses pipes and underscores, four rows high and three columns wide.
 
-```
+```text
      _   #
     | |  # zero.
     |_|  #
@@ -18,7 +18,7 @@ The binary font uses pipes and underscores, four rows high and three columns wid
 
 Is converted to "0"
 
-```
+```text
          #
       |  # one.
       |  #
@@ -39,7 +39,7 @@ Update your program to recognize multi-character binary strings, replacing garbl
 
 Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
 
-```
+```text
  _ 
  _|
 |_ 
@@ -48,7 +48,7 @@ Update your program to recognize all numbers 0 through 9, both individually and 
 
 Is converted to "2"
 
-```
+```text
       _  _     _  _  _  _  _  _  #
     | _| _||_||_ |_   ||_||_|| | # decimal numbers.
     ||_  _|  | _||_|  ||_| _||_| #
@@ -61,7 +61,7 @@ Is converted to "1234567890"
 
 Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
 
-```
+```text
     _  _ 
   | _| _|
   ||_  _|

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -8,11 +8,13 @@ Implement octal to decimal conversion.  Given an octal input
 string, your program should produce a decimal output.
 
 ## Note
+
 - Implement the conversion yourself.
   Do not use something else to perform the conversion for you.
 - Treat invalid input as octal 0.
 
 ## About Octal (Base-8)
+
 Decimal is a base-10 system.
 
 A number 233 in base 10 notation can be understood
@@ -25,7 +27,8 @@ as a linear combination of powers of 10:
 - All these values are summed.
 
 So:
-```
+
+```text
    233 # decimal
  = 2*10^2 + 3*10^1 + 3*10^0
  = 2*100  + 3*10   + 3*1
@@ -34,7 +37,8 @@ So:
 Octal is similar, but uses powers of 8 rather than powers of 10.
 
 So:
-```
+
+```text
    233 # octal
  = 2*8^2 + 3*8^1 + 3*8^0
  = 2*64  + 3*8   + 3*1

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -5,33 +5,32 @@ Detect palindrome products in a given range.
 A palindromic number is a number that remains the same when its digits are
 reversed. For example, `121` is a palindromic number but `112` is not.
 
-Given the definition of a palindromic number, we define a palindrome _product_
-to be the product `c`, such that `a * b = c`, where `c` is a palindromic number and
- `a` and `b` are integers (possibly, but _not_ necessarily palindromic numbers).
+Given a range of numbers, find the largest and smallest palindromes which
+are products of numbers within that range.
 
-For example, the palindromic number 9009 can be written as the palindrome
-product: `91 * 99 = 9009`.
-
-It's possible (and indeed common) for a palindrome product to be the product
-of multiple combinations of numbers. For example, the palindrome product `9` has
-the factors `(1, 9)`, `(3, 3)`, and `(9, 1)`.
-
-Write a program that given a range of integers, returns the smallest and largest
-palindromic product within that range, along with all of it's factors.
+Your solution should return the largest and smallest palindromes, along with the
+factors of each within the range. If the largest or smallest palindrome has more
+than one pair of factors within the range, then return all the pairs.
 
 ## Example 1
 
 Given the range `[1, 9]` (both inclusive)...
 
-The smallest product is `1`. It's factors are `(1, 1)`.
-The largest product is `9`. It's factors are `(1, 9)`, `(3, 3)`, and `(9, 1)`.
+And given the list of all possible products within this range:
+`[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 15, 21, 24, 27, 20, 28, 32, 36, 25, 30, 35, 40, 45, 42, 48, 54, 49, 56, 63, 64, 72, 81]`
+
+The palindrome products are all single digit numbers (in this case):
+`[1, 2, 3, 4, 5, 6, 7, 8, 9]`
+
+The smallest palindrome product is `1`. Its factors are `(1, 1)`.
+The largest palindrome product is `9`. Its factors are `(1, 9)` and `(3, 3)`.
 
 ## Example 2
 
 Given the range `[10, 99]` (both inclusive)...
 
-The smallest palindrome product is `121`. It's factors are `(11, 11)`.
-The largest palindrome product is `9009`. It's factors are `(91, 99)` and `(99, 91)`.
+The smallest palindrome product is `121`. Its factors are `(11, 11)`.
+The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -2,7 +2,7 @@
 
 Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
 "every letter") is a sentence using every letter of the alphabet at least once.
-The best known English pangram is: 
+The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -45,6 +45,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,11 +1,11 @@
-# Pascals Triangle
+# Pascal's Triangle
 
 Compute Pascal's triangle up to a given number of rows.
 
 In Pascal's Triangle each number is computed by adding the numbers to
 the right and left of the current position in the previous row.
 
-```plain
+```text
     1
    1 1
   1 2 1

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -5,7 +5,7 @@ Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
 
 The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
-- **Perfect**: aliquot sum = number 
+- **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6
   - 28 is a perfect number because (1 + 2 + 4 + 7 + 14) = 28
 - **Abundant**: aliquot sum > number
@@ -14,7 +14,7 @@ The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) d
 - **Deficient**: aliquot sum < number
   - 8 is a deficient number because (1 + 2 + 4) = 7
   - Prime numbers are deficient
-  
+
 Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
 
 The Scala exercises assume an SBT project scheme. The exercise solution source

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -6,14 +6,15 @@ The **North American Numbering Plan (NANP)** is a telephone numbering system use
 
 NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
 
-
 The format is usually represented as
-```
+
+```text
 (NXX)-NXX-XXXX
 ```
+
 where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
 
-Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
 
 For example, the inputs
 - `+1 (613)-995-0253`

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -10,21 +10,21 @@ Codons: `"AUG", "UUU", "UCU"`
 => which become a polypeptide with the following sequence =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
- 
-There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
-However, feel free to expand the list in the test suite to include them all.  
 
-There are also four terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
 
 All subsequent codons after are ignored, like this:
 
 RNA: `"AUGUUUUCUUAAAUG"` =>
 
-Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` => 
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 
@@ -38,7 +38,6 @@ UAU, UAC              | Tyrosine
 UGU, UGC              | Cysteine
 UGG                   | Tryptophan
 UAA, UAG, UGA         | STOP
-
 
 Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
 

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -3,13 +3,13 @@
 A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
 which,
 
-```
+```text
 a**2 + b**2 = c**2
 ```
 
-For example, 
+For example,
 
-```
+```text
 3**2 + 4**2 = 9 + 16 = 25 = 5**2.
 ```
 

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -11,7 +11,7 @@ A chessboard can be represented by an 8 by 8 array.
 So if you're told the white queen is at (2, 3) and the black queen at
 (5, 6), then you'd know you've got a set-up like so:
 
-```plain
+```text
 _ _ _ _ _ _ _ _
 _ _ _ _ _ _ _ _
 _ _ _ W _ _ _ _

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -11,41 +11,46 @@ Finally the message is then read off in rows.
 
 For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE",
 the cipherer writes out:
-```
+
+```text
 W . . . E . . . C . . . R . . . L . . . T . . . E
 . E . R . D . S . O . E . E . F . E . A . O . C .
 . . A . . . I . . . V . . . D . . . E . . . N . .
 ```
 
 Then reads off:
-```
+
+```text
 WECRLTEERDSOEEFEAOCAIVDEN
 ```
 
-
 To decrypt a message you take the zig-zag shape and fill the ciphertext along the rows.
-```
+
+```text
 ? . . . ? . . . ? . . . ? . . . ? . . . ? . . . ?
 . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
 . . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
 ```
 
 The first row has seven spots that can be filled with "WECRLTE".
-```
+
+```text
 W . . . E . . . C . . . R . . . L . . . T . . . E
 . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
 . . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
 ```
 
 Now the 2nd row takes "ERDSOEEFEAOC".
-```
+
+```text
 W . . . E . . . C . . . R . . . L . . . T . . . E
 . E . R . D . S . O . E . E . F . E . A . O . C .
 . . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
 ```
 
 Leaving "AIVDEN" for the last row.
-```
+
+```text
 W . . . E . . . C . . . R . . . L . . . T . . . E
 . E . R . D . S . O . E . E . F . E . A . O . C .
 . . A . . . I . . . V . . . D . . . E . . . N . .

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,4 +1,4 @@
-# Rna Transcription
+# RNA Transcription
 
 Given a DNA strand, return its RNA complement (per RNA transcription).
 
@@ -30,7 +30,7 @@ page](http://exercism.io/languages/scala).
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -14,7 +14,7 @@ The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
 these letters have lots of straight lines and are hence easy to hack
 into stone tablets).
 
-```
+```text
  1  => I
 10  => X
  7  => VII

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -7,20 +7,20 @@ Run-length encoding (RLE) is a simple form of data compression, where runs
 
 For example we can represent the original 53 characters with only 13.
 
-```
+```text
 "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
 ```
 
 RLE allows the original data to be perfectly reconstructed from
 the compressed data, which makes it a lossless data compression.
 
-```
+```text
 "AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
 ```
 
 For simplicity, you can assume that the unencoded string will only contain
-the letters A through Z (either lower or upper case) and whitespace. This way 
-data to be encoded will never contain any numbers and numbers inside data to 
+the letters A through Z (either lower or upper case) and whitespace. This way
+data to be encoded will never contain any numbers and numbers inside data to
 be decoded always represent the count for the following character.
 
 The Scala exercises assume an SBT project scheme. The exercise solution source

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -4,7 +4,7 @@ Detect saddle points in a matrix.
 
 So say you have a matrix like so:
 
-```plain
+```text
     0  1  2
   |---------
 0 | 9  8  7
@@ -15,7 +15,7 @@ So say you have a matrix like so:
 It has a saddle point at (1, 0).
 
 It's called a "saddle point" because it is greater than or equal to
-every element in its row and the less than or equal to every element in
+every element in its row and less than or equal to every element in
 its column.
 
 A matrix may have zero or more saddle points.

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -6,7 +6,7 @@ Given a word, compute the scrabble score for that word.
 
 You'll need these:
 
-```plain
+```text
 Letter                           Value
 A, E, I, O, U, L, N, R, S, T       1
 D, G                               2
@@ -18,6 +18,7 @@ Q, Z                               10
 ```
 
 ## Examples
+
 "cabbage" should be scored as worth 14 points:
 
 - 3 points for C
@@ -34,6 +35,7 @@ And to total:
 - = 14
 
 ## Extensions
+
 - You can play a double or a triple letter.
 - You can play a double or a triple word.
 

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -6,7 +6,7 @@
 You and your fellow cohort of those in the "know" when it comes to
 binary decide to come up with a secret "handshake".
 
-```
+```text
 1 = wink
 10 = double blink
 100 = close your eyes
@@ -40,7 +40,7 @@ page](http://exercism.io/languages/scala).
 
 ## Source
 
-Bert, in Mary Poppins [http://www.imdb.com/character/ch0011238/quotes](http://www.imdb.com/character/ch0011238/quotes)
+Bert, in Mary Poppins [http://www.imdb.com/title/tt0058331/quotes/qt0437047](http://www.imdb.com/title/tt0058331/quotes/qt0437047)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -1,4 +1,4 @@
-# Sgf Parsing
+# SGF Parsing
 
 Parsing a Smart Game Format string.
 
@@ -12,7 +12,7 @@ multiple values.
 
 An SGF file may look like this:
 
-```
+```text
 (;FF[4]C[root]SZ[19];B[aa];W[ab])
 ```
 
@@ -34,7 +34,7 @@ SGF can encode variations of play. Go players do a lot of backtracking
 in their reviews (let's try this, doesn't work, let's try that) and SGF
 supports variations of play sequences. For example:
 
-```
+```text
 (;FF[4](;B[aa];W[ab])(;B[dd];W[ee]))
 ```
 
@@ -46,7 +46,7 @@ opening to take the corner).
 
 A key can have multiple values associated with it. For example:
 
-```
+```text
 (;FF[4];AB[aa][ab][ba])
 ```
 

--- a/exercises/sgf-parsing/README.md
+++ b/exercises/sgf-parsing/README.md
@@ -74,6 +74,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -47,7 +47,7 @@ Given the key "aaaaaaaaaaaaaaaaaa", encoding the string "iamapandabear"
 would return the original "iamapandabear".
 
 Given the key "ddddddddddddddddd", encoding our string "iamapandabear"
-would return the obscured "lpdsdqgdehdu"
+would return the obscured "ldpdsdqgdehdu"
 
 In the example above, we've set a = 0 for the key value. So when the
 plaintext is added to the key, we end up with the same message coming
@@ -58,15 +58,13 @@ would get the same thing as the Caesar Cipher.
 
 The weakest link in any cipher is the human being. Let's make your
 substitution cipher a little more fault tolerant by providing a source
-of randomness and ensuring that the key is not composed of numbers or
-capital letters.
+of randomness and ensuring that the key contains only lowercase letters.
 
 If someone doesn't submit a key at all, generate a truly random key of
-at least 100 characters in length, accessible via Cipher#key (the #
-syntax means instance variable)
+at least 100 characters in length.
 
-If the key submitted has capital letters or numbers, throw an
-ArgumentError with a message to that effect.
+If the key submitted is not composed only of lowercase letters, your
+solution should handle the error in a language-appropriate way.
 
 ## Extensions
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -12,7 +12,7 @@ Given an age in seconds, calculate how old someone would be on:
    - Neptune: orbital period 164.79132 Earth years
 
 So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31 Earth-years old.
+be able to say that they're 31.69 Earth-years old.
 
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -8,7 +8,7 @@ like these examples:
 
 ###### Spiral matrix of size 3
 
-```plain
+```text
 1 2 3
 8 9 4
 7 6 5
@@ -16,7 +16,7 @@ like these examples:
 
 ###### Spiral matrix of size 4
 
-```plain
+```text
  1  2  3 4
 12 13 14 5
 11 16 15 6

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -27,6 +27,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,15 +1,12 @@
 # Sum Of Multiples
 
-Given a number, find the sum of all the multiples of particular numbers up to
+Given a number, find the sum of all the unique multiples of particular numbers up to
 but not including that number.
 
-If we list all the natural numbers up to but not including 20 that are
-multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
+If we list all the natural numbers below 20 that are multiples of 3 or 5,
+we get 3, 5, 6, 9, 10, 12, 15, and 18.
 
 The sum of these multiples is 78.
-
-Given a number, find the sum of the multiples of a given set of numbers,
-up to but not including that number.
 
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -2,23 +2,26 @@
 
 Determine if a triangle is equilateral, isosceles, or scalene.
 
-An _equilateral_ triangle has all three sides the same length.<br/>
+An _equilateral_ triangle has all three sides the same length.
+
 An _isosceles_ triangle has at least two sides the same length. (It is sometimes
 specified as having exactly two sides the same length, but for the purposes of
-this exercise we'll say at least two.)<br/>
+this exercise we'll say at least two.)
+
 A _scalene_ triangle has all sides of different lengths.
 
 ## Note
 
-For a shape to be a triangle at all, all sides have to be of length > 0, and 
-the sum of the lengths of any two sides must be greater than or equal to the 
+For a shape to be a triangle at all, all sides have to be of length > 0, and
+the sum of the lengths of any two sides must be greater than or equal to the
 length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
 
 ## Dig Deeper
 
-The case where the sum of the lengths of two sides _equals_ that of the 
-third is known as a _degenerate_ triangle - it has zero area and looks like 
+The case where the sum of the lengths of two sides _equals_ that of the
+third is known as a _degenerate_ triangle - it has zero area and looks like
 a single line. Feel free to add your own code/tests to check for degenerate triangles.
+
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise
 unit tests can be found within the exercise directory/src/test/scala.

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -11,7 +11,7 @@ Trinary numbers contain three symbols: 0, 1, and 2.
 The last place in a trinary number is the 1's place. The second to last
 is the 3's place, the third to last is the 9's place, etc.
 
-```bash
+```shell
 # "102012"
     1       0       2       0       1       2    # the number
 1*3^5 + 0*3^4 + 2*3^3 + 0*3^2 + 1*3^1 + 2*3^0    # the value

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -5,18 +5,17 @@ Implement variable length quantity encoding and decoding.
 The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
 
 In short, the goal of this encoding is to encode integer values in a way that would save bytes.
-Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte). 
-So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes. 
-Of course, you will have a variable number of bytes depending upon your integer. 
+Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte).
+So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes.
+Of course, you will have a variable number of bytes depending upon your integer.
 To indicate which is the last byte of the series, you leave bit #7 clear.
-In all of the preceding bytes, you set bit #7. 
+In all of the preceding bytes, you set bit #7.
 
-So, if an integer is between `0-127`, it can be represented as one byte. 
+So, if an integer is between `0-127`, it can be represented as one byte.
 Although VLQ can deal with numbers of arbitrary sizes, for this exercise we will restrict ourselves to only numbers that fit in a 32-bit unsigned integer.
 Here are examples of integers as 32-bit values, and the variable length quantities that they translate to:
 
-
-```
+```text
  NUMBER        VARIABLE QUANTITY
 00000000              00
 00000040              40

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -4,13 +4,12 @@ Given a phrase, count the occurrences of each word in that phrase.
 
 For example for the input `"olly olly in come free"`
 
-```plain
+```text
 olly: 2
 in: 1
 come: 1
 free: 1
 ```
-
 
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -2,7 +2,6 @@
 
 Parse and evaluate simple math word problems returning the answer as an integer.
 
-
 ## Iteration 1 — Addition
 
 Add two numbers together.
@@ -12,7 +11,6 @@ Add two numbers together.
 Evaluates to 18.
 
 Handle large numbers and negative numbers.
-
 
 ## Iteration 2 — Subtraction, Multiplication and Division
 
@@ -30,7 +28,6 @@ Now, perform the other three operations.
 
 5
 
-
 ## Iteration 3 — Multiple Operations
 
 Handle a set of operations, in sequence.
@@ -46,7 +43,6 @@ left-to-right, _ignoring the typical order of operations._
 
 15  (i.e. not 9)
 
-
 ## Bonus — Exponentials
 
 If you'd like, handle exponentials.
@@ -54,7 +50,6 @@ If you'd like, handle exponentials.
 > What is 2 raised to the 5th power?
 
 32
-
 
 The Scala exercises assume an SBT project scheme. The exercise solution source
 should be placed within the exercise directory/src/main/scala. The exercise

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -3,7 +3,7 @@
 Creating a zipper for a binary tree.
 
 [Zippers](https://en.wikipedia.org/wiki/Zipper_%28data_structure%29) are
-a way purely functional of navigating within a data structure and
+a purely functional way of navigating within a data structure and
 manipulating it.  They essentially contain a data structure and a
 pointer into that data structure (called the focus).
 

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -37,6 +37,5 @@ For more detailed info about the Scala track see the [help
 page](http://exercism.io/languages/scala).
 
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Now that we're operating with a track-wide template for generating exercise
READMEs we no longer need a separate markdown document to use for hints
and instructions that apply to all the exercises in a track. These instructions
can be defined directly in the template.

The first commit regenerates the exercise READMEs to pick up tweaks to problem descriptions, which have been updated with various formatting changes, whitespace changes, and clarifications to the description.

That gives us a clean diff when inlining the template and regenerating.

Ref: https://github.com/exercism/meta/issues/94