### PR TITLE
Remove () from methods not returning unit on robot-simulator

### DIFF
--- a/exercises/robot-simulator/example.scala
+++ b/exercises/robot-simulator/example.scala
@@ -4,18 +4,18 @@ case class Robot(bearing: Bearing, coordinates: (Int, Int)) {
   val x = coordinates._1
   val y = coordinates._2
 
-  def advance(): Robot = bearing match {
+  def advance: Robot = bearing match {
     case Bearing.North => Robot(bearing, (x, y + 1))
     case Bearing.South => Robot(bearing, (x, y - 1))
     case Bearing.East => Robot(bearing, (x + 1, y))
     case Bearing.West => Robot(bearing, (x - 1, y))
   }
 
-  def turnRight(): Robot =
+  def turnRight: Robot =
     if (bearing.id == Bearing.maxId - 1) Robot(Bearing(0), (x, y))
     else Robot(Bearing(bearing.id + 1), (x, y))
 
-  def turnLeft(): Robot =
+  def turnLeft: Robot =
     if (bearing.id == 0) Robot(Bearing(Bearing.maxId - 1), (x, y))
     else Robot(Bearing(bearing.id - 1), (x, y))
 


### PR DESCRIPTION
The convention in Scala is to only use () in a function/method that
doesn't take parameters. In this case the return type is not unit, so
the example should not have parenthesis.

I think this is important as these exercises often are part of people's first contact with the language, so seeing idiomatic examples that follow conventions can help them learn.