### PR TITLE
Add two-fer exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,6 +15,16 @@
       ]
     },
     {
+      "slug": "two-fer",
+      "uuid": "9d56454b-410a-435f-94e9-043db8c8b790",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "strings"
+      ]
+    },
+    {
       "slug": "sum-of-multiples",
       "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
       "core": true,

--- a/config.json
+++ b/config.json
@@ -397,7 +397,7 @@
       "slug": "beer-song",
       "uuid": "15047d95-671b-4163-96b2-834ec54ea3d5",
       "core": false,
-      "unlocked_by": "hello-world",
+      "unlocked_by": "two-fer",
       "difficulty": 3,
       "topics": [
         "algorithms",
@@ -410,7 +410,7 @@
       "slug": "house",
       "uuid": "73770426-74a8-498f-a37c-1b12aaf71281",
       "core": false,
-      "unlocked_by": "hello-world",
+      "unlocked_by": "two-fer",
       "difficulty": 4,
       "topics": [
         "algorithms",
@@ -714,7 +714,7 @@
       "slug": "food-chain",
       "uuid": "60deb77c-45f2-48a1-bff8-b0cef3b07500",
       "core": false,
-      "unlocked_by": "hello-world",
+      "unlocked_by": "two-fer",
       "difficulty": 5,
       "topics": [
         "algorithms",

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -1,0 +1,43 @@
+# Two Fer
+
+`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+
+Given a name, return a string with the message:
+
+```text
+One for X, one for me.
+```
+
+Where X is the given name.
+
+However, if the name is missing, return the string:
+
+```text
+One for you, one for me.
+```
+
+Here are some examples:
+
+|Name    |String to return 
+|:-------|:------------------
+|Alice   |One for Alice, one for me. 
+|Bob     |One for Bob, one for me.
+|        |One for you, one for me.
+|Zaphod  |One for Zaphod, one for me.
+
+The Scala exercises assume an SBT project scheme. The exercise solution source
+should be placed within the exercise directory/src/main/scala. The exercise
+unit tests can be found within the exercise directory/src/test/scala.
+
+To run the tests simply run the command `sbt test` in the exercise directory.
+
+For more detailed info about the Scala track see the [help
+page](http://exercism.io/languages/scala).
+
+
+## Source
+
+[https://github.com/exercism/problem-specifications/issues/757](https://github.com/exercism/problem-specifications/issues/757)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-fer/build.sbt
+++ b/exercises/two-fer/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "2.12.1"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/exercises/two-fer/example.scala
+++ b/exercises/two-fer/example.scala
@@ -1,0 +1,4 @@
+object Twofer {
+  def twofer(name: String = "you"): String =
+    s"One for $name, one for me."
+}

--- a/exercises/two-fer/src/test/scala/TwoferTest.scala
+++ b/exercises/two-fer/src/test/scala/TwoferTest.scala
@@ -1,0 +1,19 @@
+import org.scalatest.{Matchers, FunSuite}
+
+/** @version 1.2.0 */
+class TwoferTest extends FunSuite with Matchers {
+
+  test("no name given") {
+    Twofer.twofer() should be ("One for you, one for me.")
+  }
+
+  test("a name given") {
+    pending
+    Twofer.twofer("Alice") should be ("One for Alice, one for me.")
+  }
+
+  test("another name given") {
+    pending
+    Twofer.twofer("Bob") should be ("One for Bob, one for me.")
+  }
+}

--- a/testgen/src/main/scala/TwoferTestGenerator.scala
+++ b/testgen/src/main/scala/TwoferTestGenerator.scala
@@ -1,0 +1,45 @@
+import java.io.File
+
+import testgen.{CanonicalDataParser, TestCaseData, TestSuiteBuilder}
+import testgen.TestSuiteBuilder.{ToTestCaseData, withLabeledTest}
+
+object TwoferTestGenerator {
+  def main(args: Array[String]): Unit = {
+    val file = new File("src/main/resources/two-fer.json")
+
+
+    def sutArgsFromInput(parseResult: CanonicalDataParser.ParseResult, argNames: String*): String =
+      argNames map (name => toArgString(parseResult("input").asInstanceOf[Map[String, Any]](name))) mkString ", "
+
+    def toArgString(any: Any): String = {
+      any match {
+        case null => ""
+        case _ => s""""${any.toString}""""
+      }
+    }
+
+    def toExpectedString(expected: CanonicalDataParser.Expected): String = {
+      expected match {
+        case Left(_) => throw new IllegalStateException()
+        case Right(s: String) => s""""$s""""
+      }
+    }
+
+    def fromLabeledTestFromInput(argNames: String*): ToTestCaseData =
+      withLabeledTest { sut =>
+        labeledTest =>
+          val args = sutArgsFromInput(labeledTest.result, argNames: _*)
+          val property = labeledTest.property
+          val sutCall = s"""Twofer.twofer($args)"""
+          val expected = toExpectedString(labeledTest.expected)
+          TestCaseData(labeledTest.description, sutCall, expected)
+      }
+
+
+    val code = TestSuiteBuilder.build(file, fromLabeledTestFromInput("name"))
+
+    println(s"-------------")
+    println(code)
+    println(s"-------------")
+  }
+}


### PR DESCRIPTION
Add two-fer exercise.

Changed `null` test case to use empty params case instead of `null`. `null` is typically avoided in Scala. And, I did not want to introduce `Option` for an early exercise. 
This has the added benefit of introducing optional params.