### PR TITLE
Add template solution to Twofer.

### DIFF
--- a/exercises/two-fer/src/main/scala/Twofer.scala
+++ b/exercises/two-fer/src/main/scala/Twofer.scala
@@ -1,0 +1,3 @@
+object Twofer {
+  def twofer(name: String): String = ???
+}


### PR DESCRIPTION
Add an empty solution for two-fer.
There was an intent long ago to have template solutions for the first handful of the Scala core exercises. Since two-fer is now the second exercise, after hello-world, two-fer should have a template.
