### PR TITLE
Move sum-of-multiples to after leap and bob. Remove book-store as a c…

### DIFF
--- a/config.json
+++ b/config.json
@@ -926,7 +926,7 @@
       "slug": "connect",
       "uuid": "5ea6b0e1-513e-462f-9741-46f060638a92",
       "core": false,
-      "unlocked_by": "book-store",
+      "unlocked_by": "hamming",
       "difficulty": 8,
       "topics": [
         "algorithms",
@@ -941,7 +941,7 @@
       "slug": "zebra-puzzle",
       "uuid": "eb9387d6-3fac-460b-ad14-657c0f4d2d88",
       "core": false,
-      "unlocked_by": "book-store",
+      "unlocked_by": "robot-simulator",
       "difficulty": 8,
       "topics": [
         "logic"

--- a/config.json
+++ b/config.json
@@ -25,18 +25,6 @@
       ]
     },
     {
-      "slug": "sum-of-multiples",
-      "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "filtering",
-        "math",
-        "sets"
-      ]
-    },
-    {
       "slug": "leap",
       "uuid": "b600cda0-f5b8-45b3-bfd0-7e0c19a0b073",
       "core": true,
@@ -68,6 +56,18 @@
         "dates",
         "domain_specific_languages",
         "enumerations"
+      ]
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "filtering",
+        "math",
+        "sets"
       ]
     },
     {
@@ -201,16 +201,6 @@
         "parsing",
         "strings",
         "vectors"
-      ]
-    },
-    {
-      "slug": "book-store",
-      "uuid": "5ce09233-9ec1-4422-aa97-2d90ea67146b",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "recursion"
       ]
     },
     {
@@ -768,6 +758,16 @@
         "sequences",
         "strings",
         "transforming"
+      ]
+    },
+    {
+      "slug": "book-store",
+      "uuid": "5ce09233-9ec1-4422-aa97-2d90ea67146b",
+      "core": false,
+      "unlocked_by": "accumulate",
+      "difficulty": 5,
+      "topics": [
+        "recursion"
       ]
     },
     {


### PR DESCRIPTION
Reworking the progression on the core exercises.
* Move sum-of-multiples to after leap, bob and space-age.  sum-of-multiples seems to be more difficult than the other '1' difficulty exercises.
* Remove book-store as a core exercise. This one is just a major pain to mentor. I think there are probably other exercises that could be put in the book-store slot that would be more useful. And, easier to mentor. For now, I am just removing book-store...