### PR TITLE
incompatible  scalatest dependency for Collatz-conjecture exercise

### DIFF
--- a/exercises/collatz-conjecture/build.sbt
+++ b/exercises/collatz-conjecture/build.sbt
@@ -1,3 +1,3 @@
 scalaVersion := "2.12.8"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.5" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"


### PR DESCRIPTION
Fixing dependency conflicts for exercise Collatz-conjecture that causing `ClassNotFoundException Product$class`