### PR TITLE
Attempt to fix Travis CI failure by using a different JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 scala:
 - 2.11.8
 jdk:
-- oraclejdk8
+- openjdk11
 before_script:
 - bin/fetch-configlet
 - sbt test:compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@
 sudo: false
 language: scala
 scala:
-- 2.11.8
+- 2.11.9
 jdk:
 - openjdk8
 before_script:
 - bin/fetch-configlet
-- sbt test:compile
 script:
 - bin/configlet lint .
-- sbt test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 scala:
 - 2.11.8
 jdk:
-- openjdk11
+- openjdk8
 before_script:
 - bin/fetch-configlet
 - sbt test:compile


### PR DESCRIPTION
Error on travis - Expected feature release number in range of 9 to 14, but got: 8

Attempt to fix Travis CI failure by using a different JDK. Using JDK 11 instead.