### PR TITLE
Adjust core track to help ease bottlenecks

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,18 +59,6 @@
       ]
     },
     {
-      "slug": "sum-of-multiples",
-      "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "filtering",
-        "math",
-        "sets"
-      ]
-    },
-    {
       "slug": "grade-school",
       "uuid": "b469a197-adf4-4d02-b129-07f993104054",
       "core": true,
@@ -80,6 +68,67 @@
         "maps",
         "sequences",
         "sorting"
+      ]
+    },
+    {
+      "slug": "hamming",
+      "uuid": "5a31217f-02fd-4be4-b64f-7a93f36f5140",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "filtering",
+        "optional_values",
+        "strings"
+      ]
+    },
+    {
+      "slug": "etl",
+      "uuid": "d21f16ce-8e6e-436e-918b-e973cfc7c2a0",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "lists",
+        "maps",
+        "sequences",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "e810d2eb-5c90-4135-8db8-0bda54a33d2e",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "bitwise_operations",
+        "lists",
+        "strings"
+      ]
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "261f75c1-df67-4c62-a2e9-ce13550f5de3",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "enumerations",
+        "tuples"
+      ]
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "filtering",
+        "math",
+        "sets"
       ]
     },
     {
@@ -129,32 +178,6 @@
       ]
     },
     {
-      "slug": "hamming",
-      "uuid": "5a31217f-02fd-4be4-b64f-7a93f36f5140",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "filtering",
-        "optional_values",
-        "strings"
-      ]
-    },
-    {
-      "slug": "etl",
-      "uuid": "d21f16ce-8e6e-436e-918b-e973cfc7c2a0",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "lists",
-        "maps",
-        "sequences",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
       "slug": "perfect-numbers",
       "uuid": "612b8880-1dd1-410d-b530-c66ec9edc1b3",
       "core": false,
@@ -165,29 +188,6 @@
         "enumerations",
         "integers",
         "math"
-      ]
-    },
-    {
-      "slug": "secret-handshake",
-      "uuid": "e810d2eb-5c90-4135-8db8-0bda54a33d2e",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "bitwise_operations",
-        "lists",
-        "strings"
-      ]
-    },
-    {
-      "slug": "robot-simulator",
-      "uuid": "261f75c1-df67-4c62-a2e9-ce13550f5de3",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "enumerations",
-        "tuples"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -61,7 +61,7 @@
     {
       "slug": "sum-of-multiples",
       "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
@@ -85,7 +85,7 @@
     {
       "slug": "accumulate",
       "uuid": "6d136d51-390a-46a7-b42b-fdecff7b622a",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -98,7 +98,7 @@
       "slug": "flatten-array",
       "uuid": "825e94e5-6fc8-4dce-befe-74e1516fae14",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "lists",
@@ -157,7 +157,7 @@
     {
       "slug": "perfect-numbers",
       "uuid": "612b8880-1dd1-410d-b530-c66ec9edc1b3",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -193,7 +193,7 @@
     {
       "slug": "matrix",
       "uuid": "c6c37479-a030-44ba-9da5-97eb77233ac6",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -240,7 +240,7 @@
       "slug": "raindrops",
       "uuid": "54ff0017-7c53-4e83-a3bd-aff2953185b7",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "logic",
@@ -298,7 +298,7 @@
       "slug": "scrabble-score",
       "uuid": "a4797d24-9293-41b2-b630-3ac9e3840d47",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -341,7 +341,7 @@
       "slug": "sieve",
       "uuid": "9f5ee7aa-943b-4151-8530-def1428fc00f",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "filtering",
@@ -353,7 +353,7 @@
       "slug": "isogram",
       "uuid": "f6d61a0e-068b-4519-8d4d-563713be6168",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "filtering",
@@ -375,7 +375,7 @@
       "slug": "protein-translation",
       "uuid": "e6a3354e-dd32-413f-856d-53c81bd0d728",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "sequences",
@@ -412,7 +412,7 @@
       "slug": "series",
       "uuid": "35a0ff51-6c85-4a39-8017-62e8eabd1c21",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "sequences",
@@ -436,7 +436,7 @@
       "slug": "anagram",
       "uuid": "54633841-b60f-49a0-9f95-aeda09de6232",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "filtering",
@@ -482,7 +482,7 @@
       "slug": "allergies",
       "uuid": "8e311809-1de4-44c3-923a-ffd863843e6b",
       "core": false,
-      "unlocked_by": "perfect-numbers",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "enumerations",
@@ -494,7 +494,7 @@
       "slug": "all-your-base",
       "uuid": "adcf2a9b-2f6c-490f-b441-ad413a03fee7",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "integers",
@@ -508,7 +508,7 @@
       "slug": "kindergarten-garden",
       "uuid": "1218f854-ebb9-40dd-9487-ccc4d09c9a43",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "enumerations",
@@ -520,7 +520,7 @@
       "slug": "largest-series-product",
       "uuid": "7e81f24e-c892-4e45-b0bb-6c6420ba1f0e",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "integers",
@@ -559,7 +559,7 @@
       "slug": "saddle-points",
       "uuid": "aa135256-28c8-4e3e-a942-8ae5ae996ab5",
       "core": false,
-      "unlocked_by": "perfect-numbers",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "lists",
@@ -572,7 +572,7 @@
       "slug": "acronym",
       "uuid": "876a07ce-0ee4-4ded-bab3-c9b3f8746d57",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "strings",
@@ -583,7 +583,7 @@
       "slug": "run-length-encoding",
       "uuid": "163d247a-1763-4876-870a-63deb3a3daa8",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -595,7 +595,7 @@
       "slug": "roman-numerals",
       "uuid": "4c08ec90-4c5a-4dae-812c-52899b1a29cf",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -620,7 +620,7 @@
       "slug": "atbash-cipher",
       "uuid": "842f0674-fcf3-48c3-80ae-c6d43c65f270",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "security",
@@ -692,7 +692,7 @@
       "slug": "luhn",
       "uuid": "8956383c-bea2-4bcc-b7af-df19f94e15e6",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -737,7 +737,7 @@
       "slug": "custom-set",
       "uuid": "0605da19-048e-4a1f-b508-5d77d1e384a5",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "generics",
@@ -764,7 +764,7 @@
       "slug": "book-store",
       "uuid": "5ce09233-9ec1-4422-aa97-2d90ea67146b",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "recursion"
@@ -786,7 +786,7 @@
       "slug": "palindrome-products",
       "uuid": "fc57c00f-ca56-499d-bb46-0ce006b60923",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "algorithms",
@@ -801,7 +801,7 @@
       "slug": "ocr-numbers",
       "uuid": "221be13e-da2a-4f0a-9702-84744cbcaca6",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "lists",
@@ -815,7 +815,7 @@
       "slug": "pig-latin",
       "uuid": "088e1441-a648-4dc4-ad13-c5fdd8e8a104",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "strings",
@@ -839,7 +839,7 @@
       "slug": "rail-fence-cipher",
       "uuid": "755b5cf5-97f2-41c1-9b0b-24e6db68b7eb",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "algorithms",
@@ -888,7 +888,7 @@
       "slug": "minesweeper",
       "uuid": "04c3197c-cd3d-4853-af3f-50c189af80c7",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "lists",
@@ -901,7 +901,7 @@
       "slug": "wordy",
       "uuid": "ded3ae4c-43a7-46df-b43b-42aab419c2d8",
       "core": false,
-      "unlocked_by": "perfect-numbers",
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "optional_values",
@@ -914,7 +914,7 @@
       "slug": "change",
       "uuid": "62dd342a-591c-497f-8f3a-64748952b1af",
       "core": false,
-      "unlocked_by": "perfect-numbers",
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "integers",
@@ -977,7 +977,7 @@
       "slug": "sgf-parsing",
       "uuid": "8b4c7142-6790-4d89-a5cb-fa094e2c969a",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "parsing",
@@ -996,7 +996,7 @@
       "slug": "variable-length-quantity",
       "uuid": "12dbe514-848b-4fd2-868d-7f6195092e23",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "algorithms",
@@ -1009,7 +1009,7 @@
       "slug": "zipper",
       "uuid": "bc5b07e2-f641-4fda-818d-12502cdbb066",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "generics",
@@ -1068,7 +1068,7 @@
       "slug": "diamond",
       "uuid": "e45f95de-8688-46ba-80d1-470c4072c740",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "lists",
@@ -1080,7 +1080,7 @@
       "slug": "complex-numbers",
       "uuid": "48131b13-2548-4d31-9c5e-af1dac2fc94d",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "math"
@@ -1090,7 +1090,7 @@
       "slug": "rotational-cipher",
       "uuid": "67b5c1cd-7c46-4939-851d-7c10d2e908b1",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "math",
@@ -1103,7 +1103,7 @@
       "slug": "high-scores",
       "uuid": "3b161610-5b60-4661-aa24-dc026b741586",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "lists",
@@ -1114,7 +1114,7 @@
       "slug": "darts",
       "uuid": "939bfbf2-55c9-4c54-b2ef-3247bb6fc67c",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control_flow_if_else_statements",

--- a/config.json
+++ b/config.json
@@ -1117,9 +1117,9 @@
       "unlocked_by": "sum-of-multiples",
       "difficulty": 1,
       "topics": [
-        "math",
         "control_flow_if_else_statements",
-        "floating_point_numbers"
+        "floating_point_numbers",
+        "math"
       ]
     }
   ]

--- a/config.json
+++ b/config.json
@@ -35,18 +35,6 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "57b76aba-a485-464d-84ba-e9a445b25be6",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_if_else_statements",
-        "pattern_matching",
-        "strings"
-      ]
-    },
-    {
       "slug": "space-age",
       "uuid": "f147966d-97ec-4479-8679-8cad942b499a",
       "core": true,
@@ -68,6 +56,18 @@
         "maps",
         "sequences",
         "sorting"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "57b76aba-a485-464d-84ba-e9a445b25be6",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_if_else_statements",
+        "pattern_matching",
+        "strings"
       ]
     },
     {
@@ -97,6 +97,17 @@
       ]
     },
     {
+      "slug": "robot-simulator",
+      "uuid": "261f75c1-df67-4c62-a2e9-ce13550f5de3",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "enumerations",
+        "tuples"
+      ]
+    },
+    {
       "slug": "secret-handshake",
       "uuid": "e810d2eb-5c90-4135-8db8-0bda54a33d2e",
       "core": true,
@@ -106,17 +117,6 @@
         "bitwise_operations",
         "lists",
         "strings"
-      ]
-    },
-    {
-      "slug": "robot-simulator",
-      "uuid": "261f75c1-df67-4c62-a2e9-ce13550f5de3",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "enumerations",
-        "tuples"
       ]
     },
     {


### PR DESCRIPTION
**TL;DR:**
This PR reorders the core exercises; see the end for the new ordering.
Please read the full thing before replying!

---

I wrote a script that takes some data points into account to move certain core exercises to be optional side exercises, and which reorders the remaining exercises.

This is not meant to be the "be all end all" of perfection :-)
This is an attempt to make some simple changes in the short term. In the longer term, over the next 12 months, the product team will be doing a bunch of work to dig into what makes great Exercism exercises, and how to structure tracks to provide a better experience for both learners and mentors.

**Once this goes live** we will continue to monitor the continuation rate, the median wait time, and a few other stats as well, to help decide whether or not we need to take any other immediate steps. That said, if you see anything weird or worrying once the change is out, please ping us on Slack (or here) so we can discuss a fix posthaste!

**The most helpful thing you can do in reviewing this** is to look at the results and tell me whether anything is obviously terrible or suspiciously weird. I know very little about the Scala track (or the language, for that matter), so I could easily have missed something. One thing to note: there might now be a pretty big gap in difficulty between the ETL exercise and Robot Simulator. We might want to see if there are any side exercises that should be promoted to core.

I'd also appreciate it if you posted this to the mentors as a heads up, and also because mentors tend to have a great gut sense about the core exercises.

## Bottleneck detection and fixes
### Removal from core:

The following exercises were moved out of the core track:

- sum-of-multiples
- accumulate
- perfect-numbers
- matrix

This is a list of exercises that typically are unappealing to students and not very interesting to mentor. They tend to be math problems or implementations of CS algorithms and the like.

**Worth considering:** Are any of these exercises particularly valuable in the Scala track? If so, we should keep it. Let me know and I can regenerate the PR.

### Reordering:

The data that I based the reordering on was taken from the production database, and is based on the last 6 months.

I reordered by taking the original order, and then giving "penalty points" for two different things

- low continuation rates (percentage)
- long wait times in the mentor queue (median wait time in minutes)

"Continuation" is when someone completes an exercise, but then does not submit the following exercise. We have other interesting numbers that we may use to adjust things in the future, but this one seemed like our best bet for now for the bottlenecks. I somewhat arbitrarily chose 75% as the cutoff for whether or not to give penalty points, i.e. continuation rate < 75% gets penalized. The only exercise I did not penalize based on this rate was the exercise directly following `hello-world`, since `hello-world` is basically just a taste test, and it is natural to assume that many people will decide that Exercism is not really for them.

<details>
 <summary>Continuation rates</summary>

```
- hello-world (100%)
- two-fer (33%)
- leap (100%)
- bob (74%)
- space-age (89%)
- sum-of-multiples (100%)
- grade-school (81%)
- accumulate (100%)
- hamming (95%)
- etl (99%)
- perfect-numbers (99%)
- secret-handshake (92%)
- robot-simulator (88%)
- matrix (100%)
```

</details>

Long wait times in the mentor queue is an indication that mentors don't enjoy mentoring the exercise, or put it off. This could be for a number of reasons, which we have not explicitly identified, but we've observed that sometimes the exercise is simply too difficult in the current position, which means that mentors have to go back and forth a whole bunch with students to get something right, and the discussions can be quite frustrating. Also sometimes the exercise is just not very interesting to mentor. Or if the exercise is too early in the track sometimes people will submit lots of really complicated solutions rather than a small handful of mostly reasonable solutions, also making it harder to mentor.

So this pushes exercises with long wait times further back in the core track. We may decide that we need to remove some exercises from core altogether, if wait times continue to be bad.

<details>
 <summary>Wait times</summary>

```
- hello-world (0 min)
- two-fer (1013 min)
- leap (402 min)
- bob (515 min)
- space-age (840 min)
- sum-of-multiples (3721 min)
- grade-school (557 min)
- accumulate (906 min)
- hamming (588 min)
- etl (856 min)
- perfect-numbers (450 min)
- secret-handshake (2162 min)
- robot-simulator (965 min)
- matrix (369 min)
```
</details>

### Outcome

#### Before
```
- hello-world
- two-fer
- leap
- bob
- space-age
- sum-of-multiples
- grade-school
- accumulate
- hamming
- etl
- perfect-numbers
- secret-handshake
- robot-simulator
- matrix
```

#### After

_Note: the numbers indicate the position in the core track, as defined by the index of the array. Minus means that it moved earlier, plus means that it moved later._
```
- hello-world
- two-fer
- leap
- space-age (-1)
- grade-school (-1)
- hamming (-1)
- bob (+3)
- etl
- robot-simulator (-1)
- secret-handshake (+1)
```
