### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Scala combines object-oriented and functional programming in one concise, high-level language. Scala's static types help avoid bugs in complex applications, and its JVM and JavaScript runtimes let you build high-performance systems with easy access to huge ecosystems of libraries.
 
 * Features

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Installing [Scala](http://www.scala-lang.org)
+# Installing [Scala](http://www.scala-lang.org)
 
 
 In addition to the exercism CLI and your favorite text editor, practicing with Exercism exercises in Scala requires:

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Books
 
 * [Programming Scala - Dean Wampler, Ph.D.](http://shop.oreilly.com/product/0636920033073.do)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ## Recommended Learning Resources
 
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Scala for the first time. These resources can help you get started:

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running Tests
+# Running Tests
 
 With `sbt` installed, the tests can be executed from the command line with:
 

--- a/exercises/concept/basics/.docs/after.md
+++ b/exercises/concept/basics/.docs/after.md
@@ -1,3 +1,5 @@
+# After
+
 ## Key Takeaways from this Exercise
 
 **Variables**

--- a/exercises/concept/basics/.docs/hints.md
+++ b/exercises/concept/basics/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - An integer value can be defined as one or more consecutive digits.

--- a/exercises/concept/basics/.docs/instructions.md
+++ b/exercises/concept/basics/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 You have four tasks, all related to the time spent cooking the lasagna.

--- a/exercises/concept/basics/.docs/introduction.md
+++ b/exercises/concept/basics/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Defining Variables
 
 Defining a variable means assigning a value to a name. In Scala there are two kinds of variables, vals and vars.

--- a/exercises/concept/basics/.meta/design.md
+++ b/exercises/concept/basics/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a variable is.

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -3,7 +3,7 @@
 This exercise is testing mutable state that can be accessed saftely from multiple threads. Scala provides a variety of ways to protect 
 mutable state. For developers familiar with Java concurrency, Scala can utilize the Java concurrency support such as the Java synchronized block.
 
-### Common Pitfalls
+## Common Pitfalls
 
 In Scala there are two ways to achieve mutable state: Use a "var" or a mutable object.
 Two common mistakes here are:

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 This exercise is testing mutable state that can be accessed saftely from multiple threads. Scala provides a variety of ways to protect 
 mutable state. For developers familiar with Java concurrency, Scala can utilize the Java concurrency support such as the Java synchronized block.

--- a/exercises/practice/connect/.docs/instructions.append.md
+++ b/exercises/practice/connect/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 You may notice that some test cases seem unfair. However, they may be legitimately so. For example, it is common to give young or beginner players an extra n pieces at fixed positions on the board, so mismatched piece counts can occur in an otherwise fully legal game.
 
 In any case, this exercise cares only about determining a winner for a game that can have a variety of parameters, like board length and extra pieces. It is not interested in any other state of the game, such as who moved where, when, or whose turn it is.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 Note that `addGigaseconds` accepts two different types of input.

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 `Option` is used to indicate a computation that may possibly have no useful result
 (for example due to an error or invalid input).
 If you are unfamiliar with `Option` you may read [this tutorial](http://danielwestheide.com/blog/2012/12/19/the-neophytes-guide-to-scala-part-5-the-option-type.html).

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -6,7 +6,7 @@ If you are unfamiliar with `Option` you may read [this tutorial](http://danielwe
 Proper use of Monads can result in very concise yet elegant
 and readable code. Improper use can easily result in the contrary.
 Watch [this video](https://www.youtube.com/watch?v=Mw_Jnn_Y5iA) to learn more.
-#### Common pitfalls that you should avoid
+## Common pitfalls that you should avoid
 There are a few rules of thumbs for `Option`:
 1. If you don't need it don't use it. Instead of
 ```scala

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Hints
 
-#### Common pitfalls that you should avoid
+## Common pitfalls that you should avoid
 - Usually there is no need in Scala to use `return`. For a discussion see [here](http://stackoverflow.com/questions/24856106/return-in-a-scala-function-literal). Or as a quote from that discussion: *Don't use return, it makes Scala cry.*

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 
 #### Common pitfalls that you should avoid
 - Usually there is no need in Scala to use `return`. For a discussion see [here](http://stackoverflow.com/questions/24856106/return-in-a-scala-function-literal). Or as a quote from that discussion: *Don't use return, it makes Scala cry.*

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 Try to avoid code repetition, use private helper functions if you can.
 
 And you might consider using a single `Boolean` expression instead of `if-else` for better readability. See [here](http://cs.wellesley.edu/~cs111/spring00/lectures/boolean-simplification.html) on how this could be done (the link is for Java, but of course the logic is valid for Scala, too).

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 A common use of `Either` is to indicate a computation that may possibly result in an error
 (if the actual error is of no interest then the simpler `Option` type might be a better choice).
 In the absence of an error the result is usually a `Right` (mnemonic: the "right" value)

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -10,7 +10,7 @@ in this case error handling.
 Proper use of Monads can result in very concise yet elegant
 and readable code. Improper use can easily result in the contrary.
 Watch [this video](https://www.youtube.com/watch?v=Mw_Jnn_Y5iA) to learn more.
-#### Common pitfalls that you should avoid
+## Common pitfalls that you should avoid
 There are a few rules of thumbs for `Either`:
 1. If you don't need it don't use it. Instead of
 ```scala

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 According to [this terminology](http://chimera.labs.oreilly.com/books/1230000000929/ch01.html#sec_terminology) you should write a *parallel* and *deterministic*
 program and (by all means!) let Scala deal with the *concurrency* aspect.
 Or else your code could quickly get messy and error-prone with all kinds of nasty

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For simplicity and readability: Consider using the Scala collection functions instead of Java's `String` methods. Remember that in Scala a `String` is implicitly also a `Seq[Char]`, so you can call them as easily as the `String` methods.
 
 Some examples:

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 Make sure your solution is general enough to be easily scalable for longer names containing more letters and digits. This usually makes for better code quality, too.
 
 Suggestion (this is not explicitly tested):

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Hints
+# Hints
 For something a little different you might also try a solution with an `unfold` function.
 You are probably already familiar with `foldLeft/Right`: "map" a whole collection into something else (usually a non-collection).
 `unfoldLeft/Right` are the "inverse" operations: "map" something (usually a non-collection) into a collection.

--- a/exercises/practice/variable-length-quantity/.docs/instructions.append.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.append.md
@@ -1,2 +1,2 @@
-## Hints
+# Hints
 Remember that in Scala there are two forms of the right shift operator. The `>>` operator preserves the sign, while `>>>` zeroes the leftmost bits.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
