### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1252,32 +1252,32 @@
     {
       "title": "Modern",
       "content": "Scala is relatively young, and design decisions are aimed to address criticisms of Java.",
-      "icon": "features-functional"
+      "icon": "evolving"
     },
     {
       "title": "Multi-paradigm",
       "content": "Scala combines object-oriented and functional programming in one concise, high-level language.",
-      "icon": "features-oop"
+      "icon": "multi-paradigm"
     },
     {
       "title": "Statically typed",
       "content": "Scala is statically typed and supports type inference, catching errors early.",
-      "icon": "features-strongly-typed"
+      "icon": "statically-typed"
     },
     {
       "title": "Lazy computation",
       "content": "Scala evaluates expressions only when required, this increases performance.",
-      "icon": "features-lazy"
+      "icon": "fast"
     },
     {
       "title": "Immutability",
       "content": "Scala uses an immutability concept. Each declared variable is immutable by default.",
-      "icon": "features-declarative"
+      "icon": "immutable"
     },
     {
       "title": "Widely-used",
       "content": "Scala is being used by some of the world's tech giants.",
-      "icon": "features-generic"
+      "icon": "community"
     }
   ],
   "tags": [


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![evolving](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/evolving.svg) Modern
Scala is relatively young, and design decisions are aimed to address criticisms of Java.

![multi-paradigm](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/multi-paradigm.svg) Multi-paradigm
Scala combines object-oriented and functional programming in one concise, high-level language.

![statically-typed](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/statically-typed.svg) Statically typed
Scala is statically typed and supports type inference, catching errors early.

![fast](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fast.svg) Lazy computation
Scala evaluates expressions only when required, this increases performance.

![immutable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/immutable.svg) Immutability
Scala uses an immutability concept. Each declared variable is immutable by default.

![community](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/community.svg) Widely-used
Scala is being used by some of the world's tech giants.
