### PR TITLE
Security Patch: Updated .gitignore file to include auto-generated files which include personal information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ tmp
 target/
 bin/configlet
 bin/configlet.exe
+
+.bsp/
+project/
+project/target
+src/test/scala/project/
+target


### PR DESCRIPTION
Since SBT version 1.4.9. there is now an auto-generated /.bsp/sbt.json file which contains personal information, including the developer's username and folder structures. This project is using SBT 1.5.2 so the issue is occurring, and because this is a public repository this is a security issue, which this PR is being raised to fix.

There are also auto-generated project files which contain this same information, and these have been added to the .gitignore file also. 

For the Two-Fer exercise specifically the following files needed adding to the .gitignore file:
-  `exercises/practice/two-fer/.bsp/`
-  `exercises/practice/two-fer/project/`
-  `exercises/practice/two-fer/src/test/scala/project/`

However, this fix has been applied at the root/ top level of the project, so works for every exercise.

All the aforementioned files are generated when the project is compiled or the unit tests are ran using SBT.

For more information see: https://www.scala-lang.org/blog/2020/10/27/bsp-in-sbt.html