### PR TITLE
Fixes #714 - deprecated version of `scala-parser-combinators`

### DIFF
--- a/exercises/practice/alphametics/build.sbt
+++ b/exercises/practice/alphametics/build.sbt
@@ -1,5 +1,4 @@
 scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
 

--- a/exercises/practice/forth/build.sbt
+++ b/exercises/practice/forth/build.sbt
@@ -1,5 +1,3 @@
 scalaVersion := "2.13.6"
 
-
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"

--- a/exercises/practice/matching-brackets/build.sbt
+++ b/exercises/practice/matching-brackets/build.sbt
@@ -1,4 +1,3 @@
 scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"

--- a/exercises/practice/sgf-parsing/build.sbt
+++ b/exercises/practice/sgf-parsing/build.sbt
@@ -1,6 +1,5 @@
 scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
 
-
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.0"

--- a/exercises/practice/wordy/build.sbt
+++ b/exercises/practice/wordy/build.sbt
@@ -1,4 +1,3 @@
 scalaVersion := "2.13.6"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"


### PR DESCRIPTION
- removes `scala-parser-combinators` from exercises that did not need them
- bumps `scala-parser-combinators` to version `2.1.0` for `sgf-parsing` exercise
- bug introduced by https://github.com/exercism/scala/pull/712