### PR TITLE
Append Lens instructions mentioning Monocle

### DIFF
--- a/exercises/practice/lens-person/.docs/instructions.append.md
+++ b/exercises/practice/lens-person/.docs/instructions.append.md
@@ -1,2 +1,2 @@
-In scala, a popular alternative for using Lens that is supported
+In Scala, a popular alternative for using Lens that is supported
 by Exercism is [Monocle](https://www.optics.dev/Monocle/)

--- a/exercises/practice/lens-person/.docs/instructions.append.md
+++ b/exercises/practice/lens-person/.docs/instructions.append.md
@@ -1,0 +1,2 @@
+In scala, a popular alternative for using Lens that is supported
+by Exercism is [Monocle](https://www.optics.dev/Monocle/)


### PR DESCRIPTION
Explicitly mention Monocle in the instructions, since this is the library supported by Exercism for using Lens in scala.