### PR TITLE
Hamming approaches tweak

### DIFF
--- a/exercises/practice/hamming/.approaches/introduction.md
+++ b/exercises/practice/hamming/.approaches/introduction.md
@@ -62,12 +62,13 @@ object Hamming {
       case 0 => acc
       case _ =>
         distanceCount(
-          (if (s1.charAt(0) != s2.charAt(0)) acc + 1 else acc),
-          s1.substring(1),
-          s2.substring(1)
+          (if (s1.head != s2.head) acc + 1 else acc),
+          s1.tail,
+          s2.tail
         )
     }
   }
+
 }
 ```
 

--- a/exercises/practice/hamming/.approaches/match-recursion/content.md
+++ b/exercises/practice/hamming/.approaches/match-recursion/content.md
@@ -18,12 +18,13 @@ object Hamming {
       case 0 => acc
       case _ =>
         distanceCount(
-          (if (s1.charAt(0) != s2.charAt(0)) acc + 1 else acc),
-          s1.substring(1),
-          s2.substring(1)
+          (if (s1.head != s2.head) acc + 1 else acc),
+          s1.tail,
+          s2.tail
         )
     }
   }
+
 }
 ```
 
@@ -48,21 +49,9 @@ If the length is down to `0`, then the accumulated value is returned.
 If not, then `distanceCount()` is called again.
 A [ternary expression][ternary] expression is used to add to the acccumulating value if the first character in the strands are different,
 otherwise the accumulating value is passed to the next method call as is.
-A substring of each strand is passed to the next method call.
-The substring is for everything after the first character.
-Fortunately for this context, if the index is `1` past the length of the `String`, it returns an empty `String` instead of raising
-a `StringIndexOutOfBoundsException` exception.
-
-A more idiomatic way to do the same thing as the `substring()` method calls is to use the [`head()`][head] and [`tail()`][tail] methods.
-The `head()` method returns the first `Char` in the `String`, and the `tail()` method returns all of the `Char`s after the first `Char`, like so:
-
-```scala
-distanceCount(
-  (if (s1.head != s2.head) acc + 1 else acc),
-  s1.tail,
-  s2.tail
-)
-```
+The [`head()`][head] method is used to return the first `Char` in the `String`s for the comparison.
+A [`tail()`][tail] of each strand is passed to the next method call.
+The `tail()` method returns all of the `Char`s after the first `Char`.
 
 The result from `distanceCount()` is returned to `distance()` and wrapped in a [`Some`][some].
 Since the `match` expression is the last line in the function, the result from either `match` case is implicitly returned from the function

--- a/exercises/practice/hamming/.approaches/match-recursion/content.md
+++ b/exercises/practice/hamming/.approaches/match-recursion/content.md
@@ -53,6 +53,17 @@ The substring is for everything after the first character.
 Fortunately for this context, if the index is `1` past the length of the `String`, it returns an empty `String` instead of raising
 a `StringIndexOutOfBoundsException` exception.
 
+A more idiomatic way to do the same thing as the `substring()` method calls is to use the [`head()`][head] and [`tail()`][tail] methods.
+The `head()` method returns the first `Char` in the `String`, and the `tail()` method returns all of the `Char`s after the first `Char`, like so:
+
+```scala
+distanceCount(
+  (if (s1.head != s2.head) acc + 1 else acc),
+  s1.tail,
+  s2.tail
+)
+```
+
 The result from `distanceCount()` is returned to `distance()` and wrapped in a [`Some`][some].
 Since the `match` expression is the last line in the function, the result from either `match` case is implicitly returned from the function
 without needing the `return` keyword.
@@ -65,3 +76,5 @@ without needing the `return` keyword.
 [ternary]: https://alvinalexander.com/scala/scala-ternary-operator-syntax/
 [some]: https://www.scala-lang.org/api/2.13.3/scala/Some.html
 [char]: https://www.scala-lang.org/api/2.12.1/scala/Char.html
+[head]: https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/StringOps.html#head:A
+[tail]: https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/StringOps.html#tail:Repr

--- a/exercises/practice/hamming/.approaches/match-recursion/snippet.txt
+++ b/exercises/practice/hamming/.approaches/match-recursion/snippet.txt
@@ -1,8 +1,8 @@
-s1.length match {
-  case 0 => acc
-  case _ =>
-    distanceCount(
-      (if (s1.charAt(0) != s2.charAt(0)) acc + 1 else acc),
-      s1.substring(1),
-      s2.substring(1))
-}
+@tailrec def distanceCount(acc: Int, s1: String, s2: String): Int = {
+  s1.length match {
+    case 0 => acc
+    case _ =>
+      distanceCount(
+        (if (s1.head != s2.head) acc + 1 else acc),
+        s1.tail,
+        s2.tail)}}


### PR DESCRIPTION
Added the following text to the match and recursion approach:

A more idiomatic way to do the same thing as the `substring()` method calls is to use the [`head()`][head] and [`tail()`][tail] methods.
The `head()` method returns the first `Char` in the `String`, and the `tail()` method returns all of the `Char`s after the first `Char`, like so:

```scala
distanceCount(
  (if (s1.head != s2.head) acc + 1 else acc),
  s1.tail,
  s2.tail
)
```

[head]: https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/StringOps.html#head:A
[tail]: https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/StringOps.html#tail:Repr