### PR TITLE
Fix Yacht tests in online test runner

### DIFF
--- a/exercises/practice/yacht/src/test/scala/YachtTest.scala
+++ b/exercises/practice/yacht/src/test/scala/YachtTest.scala
@@ -1,7 +1,7 @@
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-class YachtTests extends AnyFunSuite with Matchers {
+class YachtTest extends AnyFunSuite with Matchers {
 
   test("Yacht") {
     Yacht.score(List(5, 5, 5, 5, 5), "yacht") shouldEqual 50


### PR DESCRIPTION
Context: https://forum.exercism.org/t/scala-test-runner-reports-error-erroneously-for-prime-factors/6314/11

Test report is generated based on class name (=> `TEST-YachtTests.xml` in main), while the test runner expects `TEST-YachtTest.xml`.
The PR aligns class name with file name.