### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/armstrong-numbers/.approaches/iterate-takewhile-last/content.md
+++ b/exercises/practice/armstrong-numbers/.approaches/iterate-takewhile-last/content.md
@@ -48,12 +48,12 @@ what iterations it will ask for.
 In this case it will keep taking iterations until the third element of the tuple is `true`, which is not set until
 creating the tuple for the iteration _after_ the first element number has been calculated down to 0.
 
-```exercism/caution
+~~~~exercism/caution
 We might be tempted to use a tuple of only two elements and `takeWhile(tup => tup._1 > 0)`,
 but this will omit the last iteration where the tuple generated is `(0,153.0)`.
 The tuple is generated, but since it has a first element of `0`, it is not _taken_.
 This is why we need the `Boolean` flag to stop _after_ we've taken the tuple with a first element of `0`.
-```
+~~~~
 
 As of this writing, Scala 3 is not yet supported on the Scala track. With Scala 3 we could destructure the tuple in the lambda like so:
 

--- a/exercises/practice/armstrong-numbers/.approaches/recursion/content.md
+++ b/exercises/practice/armstrong-numbers/.approaches/recursion/content.md
@@ -37,10 +37,10 @@ Then a [nested function][nested-function] (also called a [closure][closure]) is 
 The first argument is for the number that is being calculated.
 The second number is for totaling the results of the calculations.
 
-```exercism/note
+~~~~exercism/note
 Although the number of digits is not passed into the inner function, the inner function still has access to it.
 It is said that the value for the number of digits is _captured_ by the inner function.
-```
+~~~~
 
 The [nested function][nested-function] is annotated with the [`@tailrec`][tailrec-annotation] annotation to verify that the function can be compiled
 with [tail call optimization][tail-opt].

--- a/exercises/practice/bob/.approaches/answers-vector/content.md
+++ b/exercises/practice/bob/.approaches/answers-vector/content.md
@@ -29,10 +29,10 @@ The correct answer is selected from the array by using the score as the array in
 The `String` [`trim()`][trim] method is applied to the input to eliminate any whitespace at either end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` `String` would be different from a `String` of all whitespace.
 A `null` `String` would throw a `NullPointerException` if `trim()` were applied to it.
-```
+~~~~
 
 The first half of setting `isShout` uses the [`exists`][exists] and [`isLetter`][isletter] methods to look for
 at least one English alphabetic character.

--- a/exercises/practice/bob/.approaches/if-expressions/content.md
+++ b/exercises/practice/bob/.approaches/if-expressions/content.md
@@ -26,10 +26,10 @@ As soon as the right condition is found, the correct response is returned.
 The `String` [`trim()`][trim] method is applied to the input to eliminate any whitespace at either end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` `String` would be different from a `String` of all whitespace.
 A `null` `String` would throw a `NullPointerException` if `trim()` were applied to it.
-```
+~~~~
 
 The first half of setting `isShout` uses the [`exists`][exists] and [`isLetter`][isletter] methods to look for
 at least one English alphabetic character.

--- a/exercises/practice/bob/.approaches/match-expression/content.md
+++ b/exercises/practice/bob/.approaches/match-expression/content.md
@@ -29,10 +29,10 @@ the `isQuestion` and `isShout` values.
 The `String` [`trim()`][trim] method is applied to the input to eliminate any whitespace at either end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` `String` would be different from a `String` of all whitespace.
 A `null` `String` would throw a `NullPointerException` if `trim()` were applied to it.
-```
+~~~~
 
 The first half of setting `isShout` uses the [`exists`][exists] and [`isLetter`][isletter] methods to look for
 at least one English alphabetic character.

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~

--- a/exercises/practice/matching-brackets/.approaches/foldleft/content.md
+++ b/exercises/practice/matching-brackets/.approaches/foldleft/content.md
@@ -37,7 +37,7 @@ as is if it is already empty.
 The `isPaired()` method starts by calling the [`foldLeft()`][foldleft] method on the input `String`.
 It is initialized with an empty `List` for the "stack" and `true` for a validity flag, both wrapped in a [tuple][tuple].
 
-```exercism/note
+~~~~exercism/note
 Note that the [immutable `Stack`](https://www.scala-lang.org/api/2.12.17/scala/collection/immutable/Stack.html)
 exists only for historical reason and as an analogue of mutable stacks.
 Instead of an immutable stack you can just use a list.
@@ -45,7 +45,7 @@ Instead of an immutable stack you can just use a list.
 The [mutable `Stack`](https://www.scala-lang.org/api/2.12.17/scala/collection/mutable/Stack.html) was deprecated since version 2.12.0.
 `Stack` is an inelegant and potentially poorly-performing wrapper around List.
 Use a List assigned to a var instead.
-```
+~~~~
 
 The tuple and each character from the input is passed into the [lambda][lambda].
 A [match][match] is used to destructure the tuple and uses the [`contains()`][set-contains] method

--- a/exercises/practice/matching-brackets/.approaches/recursion/content.md
+++ b/exercises/practice/matching-brackets/.approaches/recursion/content.md
@@ -42,7 +42,7 @@ as is if it is already empty.
 The `isPaired()` method returns the result of calling the private recursive method, to which it passes the input `String`.
 and an empty `List` for the "stack".
 
-```exercism/note
+~~~~exercism/note
 Note that the [immutable `Stack`](https://www.scala-lang.org/api/2.12.17/scala/collection/immutable/Stack.html)
 exists only for historical reason and as an analogue of mutable stacks.
 Instead of an immutable stack you can just use a list.
@@ -50,7 +50,7 @@ Instead of an immutable stack you can just use a list.
 The [mutable `Stack`](https://www.scala-lang.org/api/2.12.17/scala/collection/mutable/Stack.html) was deprecated since version 2.12.0.
 `Stack` is an inelegant and potentially poorly-performing wrapper around List.
 Use a List assigned to a var instead.
-```
+~~~~
 
 The recursive method is annotated with the [`@tailrec`][tailrec-annotation] annotation to verify that the method can be compiled
 with [tail call optimization][tail-opt].

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/protein-translation/.approaches/grouped-map-takewhile/content.md
+++ b/exercises/practice/protein-translation/.approaches/grouped-map-takewhile/content.md
@@ -26,12 +26,12 @@ object ProteinTranslation {
 This approach starts by calling the [`grouped()`][grouped] method on the input `String`.
 It will take a sequence of `Char`s up to the amount passed in.
 
-```exercism/caution
+~~~~exercism/caution
 The `grouped()` treats a `String` as a plain sequence of `Char` code units and makes no attempt to keep surrogate pairs or codepoint sequences together.
 The user is responsible for making sure such cases are handled correctly.
 Failing to do so may result in an invalid Unicode `String`.
 The `grouped()` method works here because all of the characters are [ASCII](https://www.asciitable.com/).
-```
+~~~~
 
 If the remaining number of `Chars`s is less than the argument, `grouped()` will return those,
 and will be an empty `Iterator` if no `Char`s are left.

--- a/exercises/practice/protein-translation/.approaches/if-else-match-recursion/content.md
+++ b/exercises/practice/protein-translation/.approaches/if-else-match-recursion/content.md
@@ -65,12 +65,12 @@ If the protein is for a `STOP` codon, the `match` returns the `Sequence` of prot
 Otherwise, the method calls itself, using the [`drop()`][drop] method to pass in all but the first `3` `Char`s of the input `String`,
 and passing in the existing `Sequence` of proteins with the protein added to the end of it with the [`:+`][append-operator] operator.
 
-```exercism/caution
+~~~~exercism/caution
 The `take()` and `drop()` methods treat a string as a plain sequence of Char code units and makes no attempt to keep surrogate pairs or codepoint sequences together.
 The user is responsible for making sure such cases are handled correctly.
 Failing to do so may result in an invalid Unicode string.
 The `take()` and `drop()` methods work here because all of the characters are [ASCII](https://www.asciitable.com/).
-```
+~~~~
 
 [sequence]: https://www.geeksforgeeks.org/scala-sequence/
 [match]: https://docs.scala-lang.org/tour/pattern-matching.html


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705