### PR TITLE
Add circular-buffer

### DIFF
--- a/config.json
+++ b/config.json
@@ -41,9 +41,11 @@
         "slug": "basics",
         "name": "Lucians Luscious Lasagna",
         "uuid": "ea9ee1b7-26e4-4612-839d-fc6a9ecc2e7c",
-        "status": "wip",
-        "concepts": ["basics"],
-        "prerequisites": []
+        "concepts": [
+          "basics"
+        ],
+        "prerequisites": [],
+        "status": "wip"
       }
     ],
     "practice": [
@@ -273,8 +275,7 @@
         "uuid": "2be75924-fce4-49fa-b52e-6cdcf222b283",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
-        "topics": []
+        "difficulty": 3
       },
       {
         "slug": "pascals-triangle",
@@ -423,8 +424,7 @@
         "uuid": "e6e88c52-b984-479d-8b9c-047d25f2aa47",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 9,
-        "topics": []
+        "difficulty": 9
       },
       {
         "slug": "binary-search",
@@ -686,7 +686,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -696,7 +695,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -706,7 +704,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -716,7 +713,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": null,
         "status": "deprecated"
       },
       {
@@ -1278,10 +1274,17 @@
           "optional_values",
           "trees"
         ]
+      },
+      {
+        "slug": "circular-buffer",
+        "name": "Circular Buffer",
+        "uuid": "23df18c8-5fd6-4148-9f69-364d46a911b0",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },
-  "concepts": [],
   "key_features": [
     {
       "title": "Modern",
@@ -1315,19 +1318,19 @@
     }
   ],
   "tags": [
-    "runtime/jvm",
-    "platform/windows",
+    "execution_mode/compiled",
+    "paradigm/functional",
+    "paradigm/imperative",
+    "paradigm/object_oriented",
     "platform/linux",
     "platform/mac",
     "platform/web",
-    "paradigm/imperative",
-    "paradigm/functional",
-    "paradigm/object_oriented",
+    "platform/windows",
+    "runtime/jvm",
     "typing/static",
     "typing/strong",
-    "execution_mode/compiled",
     "used_for/backends",
-    "used_for/frontends",
-    "used_for/financial_systems"
+    "used_for/financial_systems",
+    "used_for/frontends"
   ]
 }

--- a/config.json
+++ b/config.json
@@ -1281,7 +1281,7 @@
         "uuid": "23df18c8-5fd6-4148-9f69-364d46a911b0",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1
+        "difficulty": 3
       }
     ]
   },

--- a/exercises/practice/circular-buffer/.docs/instructions.md
+++ b/exercises/practice/circular-buffer/.docs/instructions.md
@@ -1,0 +1,58 @@
+# Instructions
+
+A circular buffer, cyclic buffer or ring buffer is a data structure that uses a single, fixed-size buffer as if it were connected end-to-end.
+
+A circular buffer first starts empty and of some predefined length.
+For example, this is a 7-element buffer:
+
+```text
+[ ][ ][ ][ ][ ][ ][ ]
+```
+
+Assume that a 1 is written into the middle of the buffer (exact starting location does not matter in a circular buffer):
+
+```text
+[ ][ ][ ][1][ ][ ][ ]
+```
+
+Then assume that two more elements are added — 2 & 3 — which get appended after the 1:
+
+```text
+[ ][ ][ ][1][2][3][ ]
+```
+
+If two elements are then removed from the buffer, the oldest values inside the buffer are removed.
+The two elements removed, in this case, are 1 & 2, leaving the buffer with just a 3:
+
+```text
+[ ][ ][ ][ ][ ][3][ ]
+```
+
+If the buffer has 7 elements then it is completely full:
+
+```text
+[5][6][7][8][9][3][4]
+```
+
+When the buffer is full an error will be raised, alerting the client that further writes are blocked until a slot becomes free.
+
+When the buffer is full, the client can opt to overwrite the oldest data with a forced write.
+In this case, two more elements — A & B — are added and they overwrite the 3 & 4:
+
+```text
+[5][6][7][8][9][A][B]
+```
+
+3 & 4 have been replaced by A & B making 5 now the oldest data in the buffer.
+Finally, if two elements are removed then what would be returned is 5 & 6 yielding the buffer:
+
+```text
+[ ][ ][7][8][9][A][B]
+```
+
+Because there is space available, if the client again uses overwrite to store C & D then the space where 5 & 6 were stored previously will be used not the location of 7 & 8.
+7 is still the oldest element and the buffer is once again full.
+
+```text
+[C][D][7][8][9][A][B]
+```

--- a/exercises/practice/circular-buffer/.meta/Example.scala
+++ b/exercises/practice/circular-buffer/.meta/Example.scala
@@ -1,0 +1,38 @@
+class EmptyBufferException() extends Exception {}
+
+class FullBufferException() extends Exception {}
+
+class CircularBuffer(var capacity: Int) {
+  private var data = List[Int]()
+
+  def write(value: Int): Unit = {
+    if (isFull()) {
+      throw new FullBufferException
+    }
+    data = value :: data
+  }
+
+  def read(): Int = {
+    if (data.isEmpty) {
+      throw new EmptyBufferException
+    }
+
+    val last = data.last
+    data = data.init
+    last
+  }
+
+  def overwrite(value: Int): Unit = {
+    if (isFull()) {
+      read()
+    }
+    
+    write(value)
+  }
+
+  def clear(): Unit = {
+    data = List[Int]()
+  }
+
+  def isFull() = data.size == capacity
+}

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "src/main/scala/CircularBuffer.scala"
+    ],
+    "test": [
+      "src/test/scala/CircularBufferTest.scala"
+    ],
+    "example": [
+      ".meta/Example.scala"
+    ]
+  },
+  "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Circular_buffer"
+}

--- a/exercises/practice/circular-buffer/.meta/tests.toml
+++ b/exercises/practice/circular-buffer/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[28268ed4-4ff3-45f3-820e-895b44d53dfa]
+description = "reading empty buffer should fail"
+
+[2e6db04a-58a1-425d-ade8-ac30b5f318f3]
+description = "can read an item just written"
+
+[90741fe8-a448-45ce-be2b-de009a24c144]
+description = "each item may only be read once"
+
+[be0e62d5-da9c-47a8-b037-5db21827baa7]
+description = "items are read in the order they are written"
+
+[2af22046-3e44-4235-bfe6-05ba60439d38]
+description = "full buffer can't be written to"
+
+[547d192c-bbf0-4369-b8fa-fc37e71f2393]
+description = "a read frees up capacity for another write"
+
+[04a56659-3a81-4113-816b-6ecb659b4471]
+description = "read position is maintained even across multiple writes"
+
+[60c3a19a-81a7-43d7-bb0a-f07242b1111f]
+description = "items cleared out of buffer can't be read"
+
+[45f3ae89-3470-49f3-b50e-362e4b330a59]
+description = "clear frees up capacity for another write"
+
+[e1ac5170-a026-4725-bfbe-0cf332eddecd]
+description = "clear does nothing on empty buffer"
+
+[9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b]
+description = "overwrite acts like write on non-full buffer"
+
+[880f916b-5039-475c-bd5c-83463c36a147]
+description = "overwrite replaces the oldest item on full buffer"
+
+[bfecab5b-aca1-4fab-a2b0-cd4af2b053c3]
+description = "overwrite replaces the oldest item remaining in buffer following a read"
+
+[9cebe63a-c405-437b-8b62-e3fdc1ecec5a]
+description = "initial clear does not affect wrapping around"

--- a/exercises/practice/circular-buffer/build.sbt
+++ b/exercises/practice/circular-buffer/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "2.13.6"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"

--- a/exercises/practice/circular-buffer/src/main/scala/CircularBuffer.scala
+++ b/exercises/practice/circular-buffer/src/main/scala/CircularBuffer.scala
@@ -1,0 +1,14 @@
+class EmptyBufferException() extends Exception {}
+
+class FullBufferException() extends Exception {}
+
+class CircularBuffer(var capacity: Int) {
+
+  def write(value: Int) = ???
+
+  def read(): Int = ???
+
+  def overwrite(value: Int) = ???
+
+  def clear() = ???
+}

--- a/exercises/practice/circular-buffer/src/test/scala/CircularBufferTest.scala
+++ b/exercises/practice/circular-buffer/src/test/scala/CircularBufferTest.scala
@@ -1,0 +1,133 @@
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+
+class CircularBufferTest extends AnyFunSuite with Matchers {
+
+  test("Reading empty buffer should fail") {
+    val buff = new CircularBuffer(1)
+    assertThrows[EmptyBufferException](buff.read())
+  }
+
+  test("Can read an item just written") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.write(1)
+    buff.read() should be (1)
+  }
+
+  test("Each item may only be read once") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.write(1)
+    buff.read() should be (1)
+    assertThrows[EmptyBufferException](buff.read())
+  }
+
+  test("Items are read in the order they are written") {
+    pending
+    val buff = new CircularBuffer(2)
+    buff.write(1)
+    buff.write(2)
+    buff.read() should be (1)
+    buff.read() should be (2)
+  }
+
+  test("Full buffer can't be written to") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.write(1)
+    assertThrows[FullBufferException](buff.write(2))
+  }
+
+  test("A read frees up capacity for another write") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.write(1)
+    buff.read() should be (1)
+    buff.write(2)
+    buff.read() should be (2)
+  }
+
+  test("Read position is maintained even across multiple writes") {
+    pending
+    val buff = new CircularBuffer(3)
+    buff.write(1)
+    buff.write(2)
+    buff.read() should be (1)
+    buff.write(3)
+    buff.read() should be (2)
+    buff.read() should be (3)
+  }
+
+  test("Items cleared out of buffer can't be read") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.write(1)
+    buff.clear()
+    assertThrows[EmptyBufferException](buff.read())
+  }
+
+  test("Clear frees up capacity for another write") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.write(1)
+    buff.clear()
+    buff.write(2)
+    buff.read() should be (2)
+  }
+
+  test("Clear does nothing on empty buffer") {
+    pending
+    val buff = new CircularBuffer(1)
+    buff.clear()
+    buff.write(1)
+    buff.read() should be (1)
+  }
+
+  test("Overwrite acts like write on non-full buffer") {
+    pending
+    val buff = new CircularBuffer(2)
+    buff.write(1)
+    buff.overwrite(2)
+    buff.read() should be (1)
+    buff.read() should be (2)
+  }
+
+  test("Overwrite replaces the oldest item on full buffer") {
+    pending
+    val buff = new CircularBuffer(2)
+    buff.write(1)
+    buff.write(2)
+    buff.overwrite(3)
+    buff.read() should be (2)
+    buff.read() should be (3)
+  }
+
+  test("Overwrite replaces the oldest item remaining in buffer following a read") {
+    pending
+    val buff = new CircularBuffer(3)
+    buff.write(1)
+    buff.write(2)
+    buff.write(3)
+    buff.read() should be (1)
+    buff.write(4)
+    buff.overwrite(5)
+    buff.read() should be (3)
+    buff.read() should be (4)
+    buff.read() should be (5)
+  }
+
+  test("Initial clear does not affect wrapping around") {
+    pending
+    val buff = new CircularBuffer(2)
+    buff.clear()
+    buff.write(1)
+    buff.write(2)
+    buff.overwrite(3)
+    buff.overwrite(4)
+    buff.read() should be (3)
+    buff.read() should be (4)
+    assertThrows[EmptyBufferException](buff.read())
+  }
+}


### PR DESCRIPTION
@ErikSchierboom, for #48in24. I adapted the Groovy implementation, and there's some visual noise in the track config because it hadn't been formatted previously.