### PR TITLE
chore: Sync exercise documentation via configlet

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,13 +1,12 @@
 # Instructions
 
-Your task is to, given a target word and a set of candidate words, to find the subset of the candidates that are anagrams of the target.
+Given a target word and one or more candidate words, your task is to find the candidates that are anagrams of the target.
 
 An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
 A word is _not_ its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
 
-The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
-Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
-The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
-Words in the anagram set should have the same letter case as in the candidate set.
+The target word and candidate words are made up of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `"StoP"` is not an anagram of `"sTOp"`.
+The words you need to find should be taken from the candidate words, using the same letter case.
 
-Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.
+Given the target `"stone"` and the candidate words `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, and `"Seton"`, the anagram words you need to find are `"tones"`, `"notes"`, and `"Seton"`.

--- a/exercises/practice/atbash-cipher/.docs/instructions.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+Create an implementation of the Atbash cipher, an ancient encryption system created in the Middle East.
 
 The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards.
 The first letter is replaced with the last letter, the second with the second-last, and so on.

--- a/exercises/practice/change/.docs/instructions.md
+++ b/exercises/practice/change/.docs/instructions.md
@@ -1,14 +1,8 @@
 # Instructions
 
-Correctly determine the fewest number of coins to be given to a customer such that the sum of the coins' value would equal the correct amount of change.
+Determine the fewest number of coins to give a customer so that the sum of their values equals the correct amount of change.
 
-## For example
+## Examples
 
-- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) or [5, 10]
-- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5) and one dime (10) and one quarter (25) or [5, 10, 25]
-
-## Edge cases
-
-- Does your algorithm work for any given set of coins?
-- Can you ask for negative change?
-- Can you ask for a change value smaller than the smallest coin value?
+- An amount of 15 with available coin values [1, 5, 10, 25, 100] should return one coin of value 5 and one coin of value 10, or [5, 10].
+- An amount of 40 with available coin values [1, 5, 10, 25, 100] should return one coin of value 5, one coin of value 10, and one coin of value 25, or [5, 10, 25].

--- a/exercises/practice/collatz-conjecture/.docs/instructions.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.md
@@ -1,29 +1,3 @@
 # Instructions
 
-The Collatz Conjecture or 3x+1 problem can be summarized as follows:
-
-Take any positive integer n.
-If n is even, divide n by 2 to get n / 2.
-If n is odd, multiply n by 3 and add 1 to get 3n + 1.
-Repeat the process indefinitely.
-The conjecture states that no matter which number you start with, you will always reach 1 eventually.
-
-Given a number n, return the number of steps required to reach 1.
-
-## Examples
-
-Starting with n = 12, the steps would be as follows:
-
-0. 12
-1. 6
-2. 3
-3. 10
-4. 5
-5. 16
-6. 8
-7. 4
-8. 2
-9. 1
-
-Resulting in 9 steps.
-So for input n = 12, the return value would be 9.
+Given a positive integer, return the number of steps it takes to reach 1 according to the rules of the Collatz Conjecture.

--- a/exercises/practice/complex-numbers/.docs/instructions.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.md
@@ -1,29 +1,100 @@
 # Instructions
 
-A complex number is a number in the form `a + b * i` where `a` and `b` are real and `i` satisfies `i^2 = -1`.
+A **complex number** is expressed in the form `z = a + b * i`, where:
 
-`a` is called the real part and `b` is called the imaginary part of `z`.
-The conjugate of the number `a + b * i` is the number `a - b * i`.
-The absolute value of a complex number `z = a + b * i` is a real number `|z| = sqrt(a^2 + b^2)`. The square of the absolute value `|z|^2` is the result of multiplication of `z` by its complex conjugate.
+- `a` is the **real part** (a real number),
 
-The sum/difference of two complex numbers involves adding/subtracting their real and imaginary parts separately:
-`(a + i * b) + (c + i * d) = (a + c) + (b + d) * i`,
-`(a + i * b) - (c + i * d) = (a - c) + (b - d) * i`.
+- `b` is the **imaginary part** (also a real number), and
 
-Multiplication result is by definition
-`(a + i * b) * (c + i * d) = (a * c - b * d) + (b * c + a * d) * i`.
+- `i` is the **imaginary unit** satisfying `i^2 = -1`.
 
-The reciprocal of a non-zero complex number is
-`1 / (a + i * b) = a/(a^2 + b^2) - b/(a^2 + b^2) * i`.
+## Operations on Complex Numbers
 
-Dividing a complex number `a + i * b` by another `c + i * d` gives:
-`(a + i * b) / (c + i * d) = (a * c + b * d)/(c^2 + d^2) + (b * c - a * d)/(c^2 + d^2) * i`.
+### Conjugate
 
-Raising e to a complex exponent can be expressed as `e^(a + i * b) = e^a * e^(i * b)`, the last term of which is given by Euler's formula `e^(i * b) = cos(b) + i * sin(b)`.
+The conjugate of the complex number `z = a + b * i` is given by:
 
-Implement the following operations:
+```text
+zc = a - b * i
+```
 
-- addition, subtraction, multiplication and division of two complex numbers,
-- conjugate, absolute value, exponent of a given complex number.
+### Absolute Value
 
-Assume the programming language you are using does not have an implementation of complex numbers.
+The absolute value (or modulus) of `z` is defined as:
+
+```text
+|z| = sqrt(a^2 + b^2)
+```
+
+The square of the absolute value is computed as the product of `z` and its conjugate `zc`:
+
+```text
+|z|^2 = z * zc = a^2 + b^2
+```
+
+### Addition
+
+The sum of two complex numbers `z1 = a + b * i` and `z2 = c + d * i` is computed by adding their real and imaginary parts separately:
+
+```text
+z1 + z2 = (a + b * i) + (c + d * i)
+        = (a + c) + (b + d) * i
+```
+
+### Subtraction
+
+The difference of two complex numbers is obtained by subtracting their respective parts:
+
+```text
+z1 - z2 = (a + b * i) - (c + d * i)
+        = (a - c) + (b - d) * i
+```
+
+### Multiplication
+
+The product of two complex numbers is defined as:
+
+```text
+z1 * z2 = (a + b * i) * (c + d * i)
+        = (a * c - b * d) + (b * c + a * d) * i
+```
+
+### Reciprocal
+
+The reciprocal of a non-zero complex number is given by:
+
+```text
+1 / z = 1 / (a + b * i)
+      = a / (a^2 + b^2) - b / (a^2 + b^2) * i
+```
+
+### Division
+
+The division of one complex number by another is given by:
+
+```text
+z1 / z2 = z1 * (1 / z2)
+        = (a + b * i) / (c + d * i)
+        = (a * c + b * d) / (c^2 + d^2) + (b * c - a * d) / (c^2 + d^2) * i
+```
+
+### Exponentiation
+
+Raising _e_ (the base of the natural logarithm) to a complex exponent can be expressed using Euler's formula:
+
+```text
+e^(a + b * i) = e^a * e^(b * i)
+              = e^a * (cos(b) + i * sin(b))
+```
+
+## Implementation Requirements
+
+Given that you should not use built-in support for complex numbers, implement the following operations:
+
+- **addition** of two complex numbers
+- **subtraction** of two complex numbers
+- **multiplication** of two complex numbers
+- **division** of two complex numbers
+- **conjugate** of a complex number
+- **absolute value** of a complex number
+- **exponentiation** of _e_ (the base of the natural logarithm) to a complex number

--- a/exercises/practice/dominoes/.docs/instructions.md
+++ b/exercises/practice/dominoes/.docs/instructions.md
@@ -2,7 +2,9 @@
 
 Make a chain of dominoes.
 
-Compute a way to order a given set of dominoes in such a way that they form a correct domino chain (the dots on one half of a stone match the dots on the neighboring half of an adjacent stone) and that dots on the halves of the stones which don't have a neighbor (the first and last stone) match each other.
+Compute a way to order a given set of domino stones so that they form a correct domino chain.
+In the chain, the dots on one half of a stone must match the dots on the neighboring half of an adjacent stone.
+Additionally, the dots on the halves of the stones without neighbors (the first and last stone) must match each other.
 
 For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,11 +1,16 @@
 # Instructions
 
-Take a nested list and return a single flattened list with all values except nil/null.
+Take a nested array of any depth and return a fully flattened array.
 
-The challenge is to take an arbitrarily-deep nested list-like structure and produce a flattened structure without any nil/null values.
+Note that some language tracks may include null-like values in the input array, and the way these values are represented varies by track.
+Such values should be excluded from the flattened array.
 
-For example:
+Additionally, the input may be of a different data type and contain different types, depending on the track.
 
-input: [1,[2,3,null,4],[null],5]
+Check the test suite for details.
 
-output: [1,2,3,4,5]
+## Example
+
+input: `[1, [2, 6, null], [[null, [4]], 5]]`
+
+output: `[1, 2, 6, 4, 5]`

--- a/exercises/practice/grade-school/.docs/instructions.md
+++ b/exercises/practice/grade-school/.docs/instructions.md
@@ -1,21 +1,21 @@
 # Instructions
 
-Given students' names along with the grade that they are in, create a roster for the school.
+Given students' names along with the grade they are in, create a roster for the school.
 
 In the end, you should be able to:
 
-- Add a student's name to the roster for a grade
+- Add a student's name to the roster for a grade:
   - "Add Jim to grade 2."
   - "OK."
-- Get a list of all students enrolled in a grade
+- Get a list of all students enrolled in a grade:
   - "Which students are in grade 2?"
-  - "We've only got Jim just now."
+  - "We've only got Jim right now."
 - Get a sorted list of all students in all grades.
-  Grades should sort as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
-  - "Who all is enrolled in school right now?"
+  Grades should be sorted as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
+  - "Who is enrolled in school right now?"
   - "Let me think.
-    We have Anna, Barb, and Charlie in grade 1, Alex, Peter, and Zoe in grade 2 and Jim in grade 5.
-    So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
+    We have Anna, Barb, and Charlie in grade 1, Alex, Peter, and Zoe in grade 2, and Jim in grade 5.
+    So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe, and Jim."
 
-Note that all our students only have one name (It's a small town, what do you want?) and each student cannot be added more than once to a grade or the roster.
-In fact, when a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.
+Note that all our students only have one name (it's a small town, what do you want?), and each student cannot be added more than once to a grade or the roster.
+If a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.

--- a/exercises/practice/grains/.docs/instructions.md
+++ b/exercises/practice/grains/.docs/instructions.md
@@ -1,15 +1,11 @@
 # Instructions
 
-Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.
+Calculate the number of grains of wheat on a chessboard.
 
-There once was a wise servant who saved the life of a prince.
-The king promised to pay whatever the servant could dream up.
-Knowing that the king loved chess, the servant told the king he would like to have grains of wheat.
-One grain on the first square of a chess board, with the number of grains doubling on each successive square.
+A chessboard has 64 squares.
+Square 1 has one grain, square 2 has two grains, square 3 has four grains, and so on, doubling each time.
 
-There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
+Write code that calculates:
 
-Write code that shows:
-
-- how many grains were on a given square, and
+- the number of grains on a given square
 - the total number of grains on the chessboard

--- a/exercises/practice/hamming/.docs/instructions.md
+++ b/exercises/practice/hamming/.docs/instructions.md
@@ -2,15 +2,6 @@
 
 Calculate the Hamming distance between two DNA strands.
 
-Your body is made up of cells that contain DNA.
-Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells.
-In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
-
-When cells divide, their DNA replicates too.
-Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information.
-If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred.
-This is known as the "Hamming distance".
-
 We read DNA using the letters C, A, G and T.
 Two strands might look like this:
 
@@ -19,8 +10,6 @@ Two strands might look like this:
     ^ ^ ^  ^ ^    ^^
 
 They have 7 differences, and therefore the Hamming distance is 7.
-
-The Hamming distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
 
 ## Implementation notes
 

--- a/exercises/practice/luhn/.docs/instructions.md
+++ b/exercises/practice/luhn/.docs/instructions.md
@@ -1,65 +1,68 @@
 # Instructions
 
-Given a number determine whether or not it is valid per the Luhn formula.
+Determine whether a number is valid according to the [Luhn formula][luhn].
 
-The [Luhn algorithm][luhn] is a simple checksum formula used to validate a variety of identification numbers, such as credit card numbers and Canadian Social Insurance Numbers.
+The number will be provided as a string.
 
-The task is to check if a given string is valid.
-
-## Validating a Number
+## Validating a number
 
 Strings of length 1 or less are not valid.
 Spaces are allowed in the input, but they should be stripped before checking.
 All other non-digit characters are disallowed.
 
-### Example 1: valid credit card number
+## Examples
 
-```text
-4539 3195 0343 6467
-```
+### Valid credit card number
 
-The first step of the Luhn algorithm is to double every second digit, starting from the right.
-We will be doubling
+The number to be checked is `4539 3195 0343 6467`.
+
+The first step of the Luhn algorithm is to start at the end of the number and double every second digit, beginning with the second digit from the right and moving left.
 
 ```text
 4539 3195 0343 6467
 ↑ ↑  ↑ ↑  ↑ ↑  ↑ ↑  (double these)
 ```
 
-If doubling the number results in a number greater than 9 then subtract 9 from the product.
-The results of our doubling:
+If the result of doubling a digit is greater than 9, we subtract 9 from that result.
+We end up with:
 
 ```text
 8569 6195 0383 3437
 ```
 
-Then sum all of the digits:
+Finally, we sum all digits.
+If the sum is evenly divisible by 10, the original number is valid.
 
 ```text
-8+5+6+9+6+1+9+5+0+3+8+3+3+4+3+7 = 80
+8 + 5 + 6 + 9 + 6 + 1 + 9 + 5 + 0 + 3 + 8 + 3 + 3 + 4 + 3 + 7 = 80
 ```
 
-If the sum is evenly divisible by 10, then the number is valid.
-This number is valid!
+80 is evenly divisible by 10, so number `4539 3195 0343 6467` is valid!
 
-### Example 2: invalid credit card number
+### Invalid Canadian SIN
+
+The number to be checked is `066 123 468`.
+
+We start at the end of the number and double every second digit, beginning with the second digit from the right and moving left.
 
 ```text
-8273 1232 7352 0569
+066 123 478
+ ↑  ↑ ↑  ↑  (double these)
 ```
 
-Double the second digits, starting from the right
+If the result of doubling a digit is greater than 9, we subtract 9 from that result.
+We end up with:
 
 ```text
-7253 2262 5312 0539
+036 226 458
 ```
 
-Sum the digits
+We sum the digits:
 
 ```text
-7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
+0 + 3 + 6 + 2 + 2 + 6 + 4 + 5 + 8 = 36
 ```
 
-57 is not evenly divisible by 10, so this number is not valid.
+36 is not evenly divisible by 10, so number `066 123 478` is not valid!
 
 [luhn]: https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/exercises/practice/meetup/.docs/instructions.md
+++ b/exercises/practice/meetup/.docs/instructions.md
@@ -2,7 +2,7 @@
 
 Your task is to find the exact date of a meetup, given a month, year, weekday and week.
 
-There are five week values to consider: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
+There are six week values to consider: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
 
 For example, you might be asked to find the date for the meetup on the first Monday in January 2018 (January 1, 2018).
 

--- a/exercises/practice/pascals-triangle/.docs/introduction.md
+++ b/exercises/practice/pascals-triangle/.docs/introduction.md
@@ -13,7 +13,7 @@ Over the next hour, your teacher reveals some amazing things hidden in this tria
 - It contains the Fibonacci sequence.
 - If you color odd and even numbers differently, you get a beautiful pattern called the [Sierpiński triangle][wikipedia-sierpinski-triangle].
 
-The teacher implores you and your classmates to lookup other uses, and assures you that there are lots more!
+The teacher implores you and your classmates to look up other uses, and assures you that there are lots more!
 At that moment, the school bell rings.
 You realize that for the past hour, you were completely absorbed in learning about Pascal's triangle.
 You quickly grab your laptop from your bag and go outside, ready to enjoy both the sunshine _and_ the wonders of Pascal's triangle.

--- a/exercises/practice/phone-number/.docs/instructions.md
+++ b/exercises/practice/phone-number/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Clean up user-entered phone numbers so that they can be sent SMS messages.
+Clean up phone numbers so that they can be sent SMS messages.
 
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda.
 All NANP-countries share the same international country code: `1`.

--- a/exercises/practice/protein-translation/.docs/instructions.md
+++ b/exercises/practice/protein-translation/.docs/instructions.md
@@ -2,12 +2,12 @@
 
 Translate RNA sequences into proteins.
 
-RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+RNA can be broken into three-nucleotide sequences called codons, and then translated to a protein like so:
 
 RNA: `"AUGUUUUCU"` => translates to
 
 Codons: `"AUG", "UUU", "UCU"`
-=> which become a polypeptide with the following sequence =>
+=> which become a protein with the following sequence =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
@@ -27,9 +27,9 @@ Protein: `"Methionine", "Phenylalanine", "Serine"`
 
 Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
-Below are the codons and resulting Amino Acids needed for the exercise.
+Below are the codons and resulting amino acids needed for the exercise.
 
-| Codon              | Protein       |
+| Codon              | Amino Acid    |
 | :----------------- | :------------ |
 | AUG                | Methionine    |
 | UUU, UUC           | Phenylalanine |

--- a/exercises/practice/pythagorean-triplet/.docs/instructions.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.md
@@ -1,4 +1,4 @@
-# Instructions
+# Description
 
 A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for which,
 

--- a/exercises/practice/rna-transcription/.docs/instructions.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.md
@@ -1,12 +1,12 @@
 # Instructions
 
-Your task is determine the RNA complement of a given DNA sequence.
+Your task is to determine the RNA complement of a given DNA sequence.
 
 Both DNA and RNA strands are a sequence of nucleotides.
 
-The four nucleotides found in DNA are adenine (**A**), cytosine (**C**), guanine (**G**) and thymine (**T**).
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**), guanine (**G**), and thymine (**T**).
 
-The four nucleotides found in RNA are adenine (**A**), cytosine (**C**), guanine (**G**) and uracil (**U**).
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**), guanine (**G**), and uracil (**U**).
 
 Given a DNA strand, its transcribed RNA strand is formed by replacing each nucleotide with its complement:
 

--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -13,11 +13,12 @@ Or it might have one, or even several.
 Here is a grid that has exactly one candidate tree.
 
 ```text
-    1  2  3  4
-  |-----------
-1 | 9  8  7  8
-2 | 5  3  2  4  <--- potential tree house at row 2, column 1, for tree with height 5
-3 | 6  6  7  1
+      ↓
+      1  2  3  4
+    |-----------
+  1 | 9  8  7  8
+→ 2 |[5] 3  2  4
+  3 | 6  6  7  1
 ```
 
 - Row 2 has values 5, 3, 2, and 4. The largest value is 5.

--- a/exercises/practice/sieve/.docs/instructions.md
+++ b/exercises/practice/sieve/.docs/instructions.md
@@ -6,37 +6,96 @@ A prime number is a number larger than 1 that is only divisible by 1 and itself.
 For example, 2, 3, 5, 7, 11, and 13 are prime numbers.
 By contrast, 6 is _not_ a prime number as it not only divisible by 1 and itself, but also by 2 and 3.
 
-To use the Sieve of Eratosthenes, you first create a list of all the numbers between 2 and your given number.
-Then you repeat the following steps:
+To use the Sieve of Eratosthenes, first, write out all the numbers from 2 up to and including your given number.
+Then, follow these steps:
 
-1. Find the next unmarked number in your list (skipping over marked numbers).
+1. Find the next unmarked number (skipping over marked numbers).
    This is a prime number.
 2. Mark all the multiples of that prime number as **not** prime.
 
-You keep repeating these steps until you've gone through every number in your list.
+Repeat the steps until you've gone through every number.
 At the end, all the unmarked numbers are prime.
 
 ~~~~exercism/note
-The tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
-To check you are implementing the Sieve correctly, a good first test is to check that you do not use division or remainder operations.
+The Sieve of Eratosthenes marks off multiples of each prime using addition (repeatedly adding the prime) or multiplication (directly computing its multiples), rather than checking each number for divisibility.
+
+The tests don't check that you've implemented the algorithm, only that you've come up with the correct primes.
 ~~~~
 
 ## Example
 
 Let's say you're finding the primes less than or equal to 10.
 
-- List out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
+- Write out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
+
+  ```text
+  2 3 4 5 6 7 8 9 10
+  ```
+
 - 2 is unmarked and is therefore a prime.
   Mark 4, 6, 8 and 10 as "not prime".
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] 9 [10]
+  ↑
+  ```
+
 - 3 is unmarked and is therefore a prime.
   Mark 6 and 9 as not prime _(marking 6 is optional - as it's already been marked)_.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+    ↑
+  ```
+
 - 4 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+       ↑
+  ```
+
 - 5 is unmarked and is therefore a prime.
   Mark 10 as not prime _(optional - as it's already been marked)_.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+          ↑
+  ```
+
 - 6 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+             ↑
+  ```
+
 - 7 is unmarked and is therefore a prime.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                ↑
+  ```
+
 - 8 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                   ↑
+  ```
+
 - 9 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                       ↑
+  ```
+
 - 10 is marked as "not prime", so we stop as there are no more numbers to check.
 
-You've examined all numbers and found 2, 3, 5, and 7 are still unmarked, which means they're the primes less than or equal to 10.
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                           ↑
+  ```
+
+You've examined all the numbers and found that 2, 3, 5, and 7 are still unmarked, meaning they're the primes less than or equal to 10.

--- a/exercises/practice/simple-cipher/.docs/instructions.md
+++ b/exercises/practice/simple-cipher/.docs/instructions.md
@@ -11,14 +11,14 @@ If anyone wishes to decipher these, and get at their meaning, he must substitute
 Ciphers are very straight-forward algorithms that allow us to render text less readable while still allowing easy deciphering.
 They are vulnerable to many forms of cryptanalysis, but Caesar was lucky that his enemies were not cryptanalysts.
 
-The Caesar Cipher was used for some messages from Julius Caesar that were sent afield.
+The Caesar cipher was used for some messages from Julius Caesar that were sent afield.
 Now Caesar knew that the cipher wasn't very good, but he had one ally in that respect: almost nobody could read well.
 So even being a couple letters off was sufficient so that people couldn't recognize the few words that they did know.
 
-Your task is to create a simple shift cipher like the Caesar Cipher.
-This image is a great example of the Caesar Cipher:
+Your task is to create a simple shift cipher like the Caesar cipher.
+This image is a great example of the Caesar cipher:
 
-![Caesar Cipher][img-caesar-cipher]
+![Caesar cipher][img-caesar-cipher]
 
 For example:
 
@@ -44,7 +44,7 @@ would return the obscured "ldpdsdqgdehdu"
 In the example above, we've set a = 0 for the key value.
 So when the plaintext is added to the key, we end up with the same message coming out.
 So "aaaa" is not an ideal key.
-But if we set the key to "dddd", we would get the same thing as the Caesar Cipher.
+But if we set the key to "dddd", we would get the same thing as the Caesar cipher.
 
 ## Step 3
 

--- a/exercises/practice/sublist/.docs/instructions.md
+++ b/exercises/practice/sublist/.docs/instructions.md
@@ -8,8 +8,8 @@ Given any two lists `A` and `B`, determine if:
 - None of the above is true, thus lists `A` and `B` are unequal
 
 Specifically, list `A` is equal to list `B` if both lists have the same values in the same order.
-List `A` is a superlist of `B` if `A` contains a sub-sequence of values equal to `B`.
-List `A` is a sublist of `B` if `B` contains a sub-sequence of values equal to `A`.
+List `A` is a superlist of `B` if `A` contains a contiguous sub-sequence of values equal to `B`.
+List `A` is a sublist of `B` if `B` contains a contiguous sub-sequence of values equal to `A`.
 
 Examples:
 


### PR DESCRIPTION
This PR updates the documentation (instructions and introductions) for 21 Practice Exercises in the Scala track to bring them in sync with the central [problem-specifications](https://github.com/exercism/problem-specifications) repository.

The updates were automatically generated by running the following command:

```bash
./bin/configlet sync --update --docs
```

This addressed synchronization warnings for the following exercises:

- anagram (instructions)
- atbash-cipher (instructions)
- change (instructions)
- collatz-conjecture (instructions)
- complex-numbers (instructions)
- dominoes (instructions)
- flatten-array (instructions)
- grade-school (instructions)
- grains (instructions)
- hamming (instructions)
- luhn (instructions)
- meetup (instructions)
- pascals-triangle (introduction)
- phone-number (instructions)
- protein-translation (instructions)
- pythagorean-triplet (instructions)
- rna-transcription (instructions)
- saddle-points (instructions)
- sieve (instructions)
- simple-cipher (instructions)
- sublist (instructions)

This ensures that learners on the Scala track receive the latest, standardized documentation for these exercises. No manual changes were made beyond running the sync command.