### PR TITLE
Switch to Ubuntu 22.04 for CI runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Updated the CI workflow to replace Ubuntu 20.04 with 22.04. This change improves long-term support, security, and compatibility with up-to-date tools and dependencies.